### PR TITLE
Create rank checking feature

### DIFF
--- a/src/main/java/com/senither/hypixel/SkyblockAssistant.java
+++ b/src/main/java/com/senither/hypixel/SkyblockAssistant.java
@@ -22,10 +22,7 @@
 package com.senither.hypixel;
 
 import com.senither.hypixel.commands.CommandManager;
-import com.senither.hypixel.commands.administration.AutoRenameCommand;
-import com.senither.hypixel.commands.administration.DefaultRoleCommand;
-import com.senither.hypixel.commands.administration.GuildSetupCommand;
-import com.senither.hypixel.commands.administration.RankCheckCommand;
+import com.senither.hypixel.commands.administration.*;
 import com.senither.hypixel.commands.general.HelpCommand;
 import com.senither.hypixel.commands.general.VerifyCommand;
 import com.senither.hypixel.commands.misc.BotStatsCommand;
@@ -75,6 +72,7 @@ public class SkyblockAssistant {
         commandManager.registerCommand(new DefaultRoleCommand(this));
         commandManager.registerCommand(new GuildSetupCommand(this));
         commandManager.registerCommand(new RankCheckCommand(this));
+        commandManager.registerCommand(new RankRequirementCommand(this));
         commandManager.registerCommand(new VerifyCommand(this));
         commandManager.registerCommand(new SkillsCommand(this));
         commandManager.registerCommand(new SlayerCommand(this));

--- a/src/main/java/com/senither/hypixel/SkyblockAssistant.java
+++ b/src/main/java/com/senither/hypixel/SkyblockAssistant.java
@@ -25,6 +25,7 @@ import com.senither.hypixel.commands.CommandManager;
 import com.senither.hypixel.commands.administration.AutoRenameCommand;
 import com.senither.hypixel.commands.administration.DefaultRoleCommand;
 import com.senither.hypixel.commands.administration.GuildSetupCommand;
+import com.senither.hypixel.commands.administration.RankCheckCommand;
 import com.senither.hypixel.commands.general.HelpCommand;
 import com.senither.hypixel.commands.general.VerifyCommand;
 import com.senither.hypixel.commands.misc.BotStatsCommand;
@@ -73,6 +74,7 @@ public class SkyblockAssistant {
         commandManager.registerCommand(new AutoRenameCommand(this));
         commandManager.registerCommand(new DefaultRoleCommand(this));
         commandManager.registerCommand(new GuildSetupCommand(this));
+        commandManager.registerCommand(new RankCheckCommand(this));
         commandManager.registerCommand(new VerifyCommand(this));
         commandManager.registerCommand(new SkillsCommand(this));
         commandManager.registerCommand(new SlayerCommand(this));

--- a/src/main/java/com/senither/hypixel/commands/administration/RankCheckCommand.java
+++ b/src/main/java/com/senither/hypixel/commands/administration/RankCheckCommand.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.commands.administration;
+
+import com.senither.hypixel.Constants;
+import com.senither.hypixel.SkyblockAssistant;
+import com.senither.hypixel.chat.MessageFactory;
+import com.senither.hypixel.chat.PlaceholderMessage;
+import com.senither.hypixel.contracts.commands.SkillCommand;
+import com.senither.hypixel.database.controller.GuildController;
+import com.senither.hypixel.exceptions.FriendlyException;
+import com.senither.hypixel.rank.RankCheckResponse;
+import com.senither.hypixel.rank.RankRequirementType;
+import com.senither.hypixel.rank.items.PowerOrb;
+import com.senither.hypixel.utils.NumberUtil;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.hypixel.api.reply.GuildReply;
+import net.hypixel.api.reply.PlayerReply;
+import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+
+public class RankCheckCommand extends SkillCommand {
+
+    public RankCheckCommand(SkyblockAssistant app) {
+        super(app, "Rank Check");
+    }
+
+    @Override
+    public String getName() {
+        return "Rank Check";
+    }
+
+    @Override
+    public List<String> getDescription() {
+        return Arrays.asList(
+            "This command can be used in combination with the `:commandrank-requirement` command to check",
+            "what rank a given user falls under using their currently fairy soul, gear, armor,",
+            "slayer, power orb, and average skill level stats."
+        );
+    }
+
+    @Override
+    public List<String> getUsageInstructions() {
+        return Collections.singletonList(
+            "`:command <username> [profile]` - Check what rank the given user meets the requirements for."
+        );
+    }
+
+    @Override
+    public List<String> getExampleUsage() {
+        return Collections.singletonList(
+            "`:command Senither`"
+        );
+    }
+
+    @Override
+    public List<String> getTriggers() {
+        return Arrays.asList("rank-check", "rankcheck");
+    }
+
+    @Override
+    protected boolean prepareCommand(MessageReceivedEvent event, String username) {
+        GuildController.GuildEntry guildEntry = GuildController.getGuildById(app.getDatabaseManager(), event.getGuild().getIdLong());
+        if (guildEntry == null) {
+            MessageFactory.makeError(event.getMessage(),
+                "The server is not currently setup with a guild, you must setup "
+                    + "the server with a guild before you can use this command!"
+            ).setTitle("Server is not setup").queue();
+            return false;
+        }
+
+        if (guildEntry.getRankRequirements().isEmpty()) {
+            MessageFactory.makeError(event.getMessage(),
+                "There are currently no rank requirements setup for the server, you "
+                    + "must first setup the requirements for the different guild ranks you want "
+                    + "to be able to check for using `:command`."
+            )
+                .set("command", Constants.COMMAND_PREFIX + "rank-requirement")
+                .setTitle("Rank Requirements is not setup")
+                .queue();
+            return false;
+        }
+
+        if (!isGuildMasterOrOfficerOfServerGuild(event, guildEntry)) {
+            MessageFactory.makeError(event.getMessage(),
+                "You must be the guild master or an officer of the **:name** guild to use this command!"
+            ).set("name", guildEntry.getName()).setTitle("Missing permissions").queue();
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    @SuppressWarnings("ConstantConditions")
+    protected void handleSkyblockProfile(Message message, SkyBlockProfileReply profileReply, PlayerReply playerReply) {
+        GuildController.GuildEntry guildEntry = GuildController.getGuildById(app.getDatabaseManager(), message.getGuild().getIdLong());
+        GuildReply guildReply = app.getHypixel().getGson().fromJson(guildEntry.getData(), GuildReply.class);
+        String uuidAsString = playerReply.getPlayer().get("uuid").getAsString();
+
+        UUID uuid = UUID.fromString(
+            uuidAsString.substring(0, 8) + "-" +
+                uuidAsString.substring(8, 12) + "-" +
+                uuidAsString.substring(12, 16) + "-" +
+                uuidAsString.substring(16, 20) + "-" +
+                uuidAsString.substring(20, 32)
+        );
+
+        PlaceholderMessage placeholderMessage = MessageFactory.makeSuccess(message, "**:user** has **:amount** out of **190** fairy souls!")
+            .setTitle(playerReply.getPlayer().get("displayname").getAsString() + "'s Rank Check")
+            .set("user", playerReply.getPlayer().get("displayname").getAsString());
+
+        RankCheckResponse rankCheckResponse = RankRequirementType.FAIRY_SOULS.getChecker().getRankForUser(guildEntry, guildReply, profileReply, uuid);
+        placeholderMessage.set("amount", rankCheckResponse.getMetric().getOrDefault("amount", 0));
+        placeholderMessage
+            .addField(RankRequirementType.AVERAGE_SKILLS.getName(), getRankForType(
+                RankRequirementType.AVERAGE_SKILLS, guildEntry, guildReply, profileReply, uuid, response -> {
+                    return formatRank(response) + NumberUtil.formatNicelyWithDecimals(
+                        (Double) response.getMetric().getOrDefault("amount", 0D)
+                    ) + " Average Skill";
+                }
+            ), true)
+            .addField(RankRequirementType.SLAYER.getName(), getRankForType(
+                RankRequirementType.SLAYER, guildEntry, guildReply, profileReply, uuid, response -> {
+                    return formatRank(response) + NumberUtil.formatNicely(
+                        (Long) response.getMetric().getOrDefault("amount", 0)
+                    ) + " Total XP";
+                }
+            ), true)
+            .addField(RankRequirementType.TALISMANS.getName(), getRankForType(
+                RankRequirementType.TALISMANS, guildEntry, guildReply, profileReply, uuid, response -> {
+                    int legendaries = (int) response.getMetric().get("legendaries");
+                    int epics = (int) response.getMetric().get("epics");
+
+                    return formatRank(response) + String.format("%s Legendaries & %s Epics", legendaries, epics);
+                }
+            ), true)
+            .addField(RankRequirementType.POWER_ORBS.getName(), getRankForType(
+                RankRequirementType.POWER_ORBS, guildEntry, guildReply, profileReply, uuid, response -> {
+                    PowerOrb powerOrb = (PowerOrb) response.getMetric().get("item");
+
+                    return formatRank(response) + powerOrb.getName();
+                }
+            ), true)
+            .addField(RankRequirementType.ARMOR.getName(), getRankForType(
+                RankRequirementType.ARMOR, guildEntry, guildReply, profileReply, uuid, this::formatRank
+            ), true)
+            .addField(RankRequirementType.WEAPONS.getName(), getRankForType(
+                RankRequirementType.WEAPONS, guildEntry, guildReply, profileReply, uuid, this::formatRank
+            ), true);
+
+        message.editMessage(placeholderMessage.buildEmbed()).queue();
+    }
+
+    private String formatRank(RankCheckResponse response) {
+        return "__" + response.getRank().getName() + "__\n";
+    }
+
+    private String getRankForType(
+        RankRequirementType rankRequirementType,
+        GuildController.GuildEntry guildEntry,
+        GuildReply guildReply,
+        SkyBlockProfileReply profileReply,
+        UUID playerUUID,
+        Function<RankCheckResponse, String> metricsCallback
+    ) {
+        try {
+            RankCheckResponse response = rankRequirementType.getChecker().getRankForUser(
+                guildEntry, guildReply, profileReply, playerUUID
+            );
+
+            if (response == null || response.getRank() == null) {
+                return "_Unranked_";
+            }
+
+            String metricMessage = metricsCallback.apply(response);
+            if (metricMessage == null) {
+                return response.getRank().getName();
+            }
+            return metricMessage;
+        } catch (FriendlyException e) {
+            return "API is Disabled!";
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "Unknown error occurred!";
+        }
+    }
+}

--- a/src/main/java/com/senither/hypixel/commands/administration/RankRequirementCommand.java
+++ b/src/main/java/com/senither/hypixel/commands/administration/RankRequirementCommand.java
@@ -117,7 +117,7 @@ public class RankRequirementCommand extends Command {
             case "reset":
             case "delete":
                 resetRankOption(event, guildEntry, rank);
-                break;
+                return;
 
             case "skill":
             case "skills":

--- a/src/main/java/com/senither/hypixel/commands/administration/RankRequirementCommand.java
+++ b/src/main/java/com/senither/hypixel/commands/administration/RankRequirementCommand.java
@@ -34,6 +34,7 @@ import net.hypixel.api.reply.GuildReply;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class RankRequirementCommand extends Command {
@@ -49,22 +50,37 @@ public class RankRequirementCommand extends Command {
 
     @Override
     public List<String> getDescription() {
-        return Arrays.asList();
+        return Arrays.asList(
+            "The command can be used to setup the requirement for each role, which the bot can",
+            String.format("then use to check what role a user belongs to using the `%srank-check` command.", Constants.COMMAND_PREFIX),
+            "\nSetting up Weapon and Armors is a bit different compared to all the other requirements types, you'll",
+            "need to both set the point requirement, and the item sets and how many points they're worth."
+        );
     }
 
     @Override
     public List<String> getUsageInstructions() {
-        return Arrays.asList();
+        return Arrays.asList(
+            "`:command` - Lists all the ranks in the guild.",
+            "`:command <rank>` - Lists all requirements set for the given rank.",
+            "`:command <rank> <type> <value>` - Sets the value for the type for the given rank."
+        );
     }
 
     @Override
     public List<String> getExampleUsage() {
-        return Arrays.asList();
+        return Arrays.asList(
+            "`:command vizier souls 190` - Sets the Fairy Soul requirement to 190 souls",
+            "`:command vizier talismans 3 5` - Sets the Talisman requirement to 3 Legendaries, and 5 Epics",
+            "`:command vizier orb 2` - Sets the Power Orb requirement to Mana Flux",
+            "`:command vizier weapon points 10` - Sets the Weapon point requirement for Vizer to 10 points",
+            "`:command vizier weapon item aotd 5` - Sets the AOTD worth for Vizer to 5 points"
+        );
     }
 
     @Override
     public List<String> getTriggers() {
-        return Arrays.asList("rank-requirement");
+        return Collections.singletonList("rank-requirement");
     }
 
     @Override

--- a/src/main/java/com/senither/hypixel/commands/administration/RankRequirementCommand.java
+++ b/src/main/java/com/senither/hypixel/commands/administration/RankRequirementCommand.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.commands.administration;
+
+import com.senither.hypixel.Constants;
+import com.senither.hypixel.SkyblockAssistant;
+import com.senither.hypixel.chat.MessageFactory;
+import com.senither.hypixel.chat.PlaceholderMessage;
+import com.senither.hypixel.contracts.commands.Command;
+import com.senither.hypixel.database.controller.GuildController;
+import com.senither.hypixel.rank.RankRequirementType;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.hypixel.api.reply.GuildReply;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class RankRequirementCommand extends Command {
+
+    public RankRequirementCommand(SkyblockAssistant app) {
+        super(app);
+    }
+
+    @Override
+    public String getName() {
+        return "Rank Requirement";
+    }
+
+    @Override
+    public List<String> getDescription() {
+        return Arrays.asList();
+    }
+
+    @Override
+    public List<String> getUsageInstructions() {
+        return Arrays.asList();
+    }
+
+    @Override
+    public List<String> getExampleUsage() {
+        return Arrays.asList();
+    }
+
+    @Override
+    public List<String> getTriggers() {
+        return Arrays.asList("rank-requirement");
+    }
+
+    @Override
+    public void onCommand(MessageReceivedEvent event, String[] args) {
+        GuildController.GuildEntry guildEntry = GuildController.getGuildById(app.getDatabaseManager(), event.getGuild().getIdLong());
+        if (guildEntry == null) {
+            MessageFactory.makeError(event.getMessage(),
+                "The server is not currently setup with a guild, you must setup "
+                    + "the server with a guild before you can use this command!"
+            ).setTitle("Server is not setup").queue();
+            return;
+        }
+
+        if (!isGuildMasterOrOfficerOfServerGuild(event, guildEntry)) {
+            MessageFactory.makeError(event.getMessage(),
+                "You must be the guild master or an officer of the **:name** guild to use this command!"
+            ).set("name", guildEntry.getName()).setTitle("Missing permissions").queue();
+            return;
+        }
+
+        GuildReply guildReply = app.getHypixel().getGson().fromJson(guildEntry.getData(), GuildReply.class);
+
+        if (args.length == 0) {
+            sendListOfGuildRanks(event, guildEntry, guildReply);
+            return;
+        }
+
+        GuildReply.Guild.Rank rank = null;
+        for (GuildReply.Guild.Rank guildRank : guildReply.getGuild().getRanks()) {
+            if (guildRank.getName().equalsIgnoreCase(args[0])) {
+                rank = guildRank;
+                break;
+            }
+        }
+
+        if (rank == null) {
+            MessageFactory.makeWarning(event.getMessage(),
+                "You must mention a valid Guild rank to use this command!"
+            ).setTitle("Invalid Guild Rank").queue();
+            return;
+        }
+
+        if (args.length == 1) {
+            sendRankRequirements(event, guildEntry, guildReply, rank);
+            return;
+        }
+
+        RankRequirementType action = null;
+        switch (args[1].toLowerCase()) {
+            case "reset":
+            case "delete":
+                resetRankOption(event, guildEntry, rank);
+                break;
+
+            case "skill":
+            case "skills":
+                action = RankRequirementType.AVERAGE_SKILLS;
+                break;
+
+            case "fairy":
+            case "soul":
+            case "souls":
+                action = RankRequirementType.FAIRY_SOULS;
+                break;
+
+            case "slayer":
+            case "slayers":
+                action = RankRequirementType.SLAYER;
+                break;
+
+            case "armor":
+            case "armors":
+                action = RankRequirementType.ARMOR;
+                break;
+
+            case "weapon":
+            case "weapons":
+                action = RankRequirementType.WEAPONS;
+                break;
+
+            case "talis":
+            case "talisman":
+            case "talismans":
+                action = RankRequirementType.TALISMANS;
+                break;
+
+            case "orb":
+            case "orbs":
+            case "powerorb":
+                action = RankRequirementType.POWER_ORBS;
+                break;
+        }
+
+        if (action == null) {
+            MessageFactory.makeWarning(event.getMessage(), "Invalid role option, `:value` is not a valid option!")
+                .set("value", args[0])
+                .setTitle("Invalid Option")
+                .queue();
+            return;
+        }
+
+        action.getHandler().handle(app, event, guildEntry, rank, Arrays.copyOfRange(args, 2, args.length));
+    }
+
+    private void sendListOfGuildRanks(MessageReceivedEvent event, GuildController.GuildEntry guildEntry, GuildReply guildReply) {
+        PlaceholderMessage message = MessageFactory.makeInfo(event.getMessage(),
+            "\uD83D\uDEE0 Has requirements setup \uD83D\uDD27 Doesn't have requirements setup\n\n:note"
+        ).setTitle("Rank Requirements");
+
+        List<String> roles = new ArrayList<>();
+        guildReply.getGuild().getRanks()
+            .stream().sorted((o1, o2) -> o2.getPriority() - o1.getPriority())
+            .forEach(rank -> {
+                roles.add(String.format("%s %s",
+                    guildEntry.getRankRequirements().containsKey(rank.getName())
+                        ? "\uD83D\uDEE0"
+                        : "\uD83D\uDD27",
+                    rank.getName()
+                ));
+            });
+
+        message.set("note", String.join("\n", roles))
+            .setFooter(String.format("You can use \"%srank-requirement <role> <option>\" to setup requirements",
+                Constants.COMMAND_PREFIX
+            ))
+            .queue();
+    }
+
+    private void sendRankRequirements(MessageReceivedEvent event, GuildController.GuildEntry guildEntry, GuildReply guildReply, GuildReply.Guild.Rank rank) {
+        GuildController.GuildEntry.RankRequirement requirement = guildEntry.getRankRequirements().get(rank.getName());
+        if (requirement == null) {
+            MessageFactory.makeWarning(event.getMessage(),
+                "There are no rank requirements setup for the **:name** rank!"
+            ).set("name", rank.getName()).queue();
+            return;
+        }
+
+        PlaceholderMessage message = MessageFactory.makeInfo(event.getMessage(), "")
+            .setTitle("Rank Requirements for " + rank.getName());
+
+        for (RankRequirementType requirementType : RankRequirementType.values()) {
+            try {
+                message.addField(
+                    requirementType.getName(),
+                    requirementType.getChecker().getRankRequirementNote(requirement),
+                    false
+                );
+            } catch (Exception e) {
+            }
+        }
+
+        message.queue();
+    }
+
+    private void resetRankOption(MessageReceivedEvent event, GuildController.GuildEntry guildEntry, GuildReply.Guild.Rank rank) {
+        guildEntry.getRankRequirements().remove(rank.getName());
+        updateGuildEntry(event, guildEntry);
+
+        MessageFactory.makeSuccess(event.getMessage(), "All the rank requirements for the **:name** role have been reset!")
+            .set("name", rank.getName())
+            .queue();
+    }
+
+    private void updateGuildEntry(MessageReceivedEvent event, GuildController.GuildEntry guildEntry) {
+        try {
+            app.getDatabaseManager().queryUpdate("UPDATE `guilds` SET `rank_requirements` = ? WHERE `discord_id` = ?",
+                app.getHypixel().getGson().toJson(guildEntry.getRankRequirements()), event.getGuild().getIdLong()
+            );
+
+            GuildController.forgetCacheFor(event.getGuild().getIdLong());
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/senither/hypixel/commands/general/HelpCommand.java
+++ b/src/main/java/com/senither/hypixel/commands/general/HelpCommand.java
@@ -91,7 +91,8 @@ public class HelpCommand extends Command {
         PlaceholderMessage message = MessageFactory.makeInfo(event.getMessage(), String.join(" ", container.getDescription()))
             .setTitle(container.getName())
             .addField("Usage", formatCommandUsage(container, container.getCommand().getUsageInstructions()), false)
-            .addField("Example", formatCommandUsage(container, container.getCommand().getExampleUsage()), false);
+            .addField("Example", formatCommandUsage(container, container.getCommand().getExampleUsage()), false)
+            .set("command", Constants.COMMAND_PREFIX);
 
         if (container.getTriggers().size() > 1) {
             StringBuilder aliases = new StringBuilder();

--- a/src/main/java/com/senither/hypixel/contracts/commands/SkillCommand.java
+++ b/src/main/java/com/senither/hypixel/contracts/commands/SkillCommand.java
@@ -79,6 +79,10 @@ public abstract class SkillCommand extends Command {
             return;
         }
 
+        if (!prepareCommand(event, username)) {
+            return;
+        }
+
         EmbedBuilder embedBuilder = new EmbedBuilder()
             .setTitle(username + "'s " + type.substring(0, 1).toUpperCase() + type.substring(1, type.length()) + "s")
             .setDescription("Loading Skyblock profile data for " + username + "!")
@@ -130,7 +134,6 @@ public abstract class SkillCommand extends Command {
                     .addField("Valid Profiles", "`" + String.join("`, `", profileNames) + "`", false)
                     .buildEmbed()
                 ).queue();
-
             } catch (InterruptedException | ExecutionException | TimeoutException e) {
                 log.error("Failed to fetch player data for {}, error: {}",
                     username, e.getMessage(), e
@@ -272,6 +275,10 @@ public abstract class SkillCommand extends Command {
             uuid.substring(16, 20) + "-" +
             uuid.substring(20, 32)
         );
+    }
+
+    protected boolean prepareCommand(MessageReceivedEvent event, String username) {
+        return true;
     }
 
     protected abstract void handleSkyblockProfile(Message message, SkyBlockProfileReply profileReply, PlayerReply playerReply);

--- a/src/main/java/com/senither/hypixel/contracts/rank/ItemRequirement.java
+++ b/src/main/java/com/senither/hypixel/contracts/rank/ItemRequirement.java
@@ -19,15 +19,13 @@
  *
  */
 
-package com.senither.hypixel.exceptions;
+package com.senither.hypixel.contracts.rank;
 
-public class FriendlyException extends RuntimeException {
+import java.util.List;
 
-    public FriendlyException(String message) {
-        super(message);
-    }
+public interface ItemRequirement {
 
-    public FriendlyException(String message, String... args) {
-        super(String.format(message, args));
-    }
+    String getName();
+
+    List<String> getAliases();
 }

--- a/src/main/java/com/senither/hypixel/contracts/rank/ObjectClosure.java
+++ b/src/main/java/com/senither/hypixel/contracts/rank/ObjectClosure.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.contracts.rank;
+
+import com.senither.hypixel.database.controller.GuildController;
+
+@FunctionalInterface
+public interface ObjectClosure<T> {
+
+    void run(GuildController.GuildEntry.RankRequirement requirement, T value);
+}

--- a/src/main/java/com/senither/hypixel/contracts/rank/RankCommandHandler.java
+++ b/src/main/java/com/senither/hypixel/contracts/rank/RankCommandHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.contracts.rank;
+
+import com.senither.hypixel.SkyblockAssistant;
+import com.senither.hypixel.database.controller.GuildController;
+import com.senither.hypixel.rank.RankRequirementType;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.hypixel.api.reply.GuildReply;
+
+import java.sql.SQLException;
+
+public abstract class RankCommandHandler {
+
+    protected RankRequirementType rankType;
+
+    public void setRankType(RankRequirementType rankType) {
+        this.rankType = rankType;
+    }
+
+    protected GuildController.GuildEntry.RankRequirement getRequirementsForRank(GuildController.GuildEntry guildEntry, GuildReply.Guild.Rank rank) {
+        if (!guildEntry.getRankRequirements().containsKey(rank.getName())) {
+            guildEntry.getRankRequirements().put(rank.getName(), GuildController.createEmptyRankRequirement());
+        }
+        return guildEntry.getRankRequirements().get(rank.getName());
+    }
+
+    protected void updateGuildEntry(SkyblockAssistant app, MessageReceivedEvent event, GuildController.GuildEntry guildEntry) {
+        try {
+            app.getDatabaseManager().queryUpdate("UPDATE `guilds` SET `rank_requirements` = ? WHERE `discord_id` = ?",
+                app.getHypixel().getGson().toJson(guildEntry.getRankRequirements()), event.getGuild().getIdLong()
+            );
+
+            GuildController.forgetCacheFor(event.getGuild().getIdLong());
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public abstract void handle(SkyblockAssistant app, MessageReceivedEvent event, GuildController.GuildEntry guildEntry, GuildReply.Guild.Rank rank, String[] args);
+
+}

--- a/src/main/java/com/senither/hypixel/contracts/rank/RankRequirementChecker.java
+++ b/src/main/java/com/senither/hypixel/contracts/rank/RankRequirementChecker.java
@@ -24,6 +24,7 @@ package com.senither.hypixel.contracts.rank;
 import com.google.gson.JsonObject;
 import com.senither.hypixel.database.controller.GuildController;
 import com.senither.hypixel.inventory.Inventory;
+import com.senither.hypixel.rank.RankCheckResponse;
 import net.hypixel.api.reply.GuildReply;
 import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
 
@@ -34,7 +35,7 @@ import java.util.stream.Collectors;
 
 public abstract class RankRequirementChecker {
 
-    public GuildReply.Guild.Rank getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
+    public RankCheckResponse getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
         throw new UnsupportedOperationException("Getting rank for the given user is not supported by this requirement type!");
     }
 

--- a/src/main/java/com/senither/hypixel/contracts/rank/RankRequirementChecker.java
+++ b/src/main/java/com/senither/hypixel/contracts/rank/RankRequirementChecker.java
@@ -21,10 +21,13 @@
 
 package com.senither.hypixel.contracts.rank;
 
+import com.google.gson.JsonObject;
 import com.senither.hypixel.database.controller.GuildController;
+import com.senither.hypixel.inventory.Inventory;
 import net.hypixel.api.reply.GuildReply;
 import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -39,5 +42,9 @@ public abstract class RankRequirementChecker {
         return guild.getGuild().getRanks().stream()
             .sorted((o1, o2) -> o2.getPriority() - o1.getPriority())
             .collect(Collectors.toList());
+    }
+
+    protected final Inventory buildInventoryForPlayer(JsonObject member, String inventoryName) throws IOException {
+        return new Inventory(member.get(inventoryName).getAsJsonObject().get("data").getAsString());
     }
 }

--- a/src/main/java/com/senither/hypixel/contracts/rank/RankRequirementChecker.java
+++ b/src/main/java/com/senither/hypixel/contracts/rank/RankRequirementChecker.java
@@ -39,6 +39,10 @@ public abstract class RankRequirementChecker {
         throw new UnsupportedOperationException("Getting rank for the given user is not supported by this requirement type!");
     }
 
+    public String getRankRequirementNote(GuildController.GuildEntry.RankRequirement requirement) {
+        throw new UnsupportedOperationException("Getting rank note for the given rank is not supported by this requirement type!");
+    }
+
     protected final List<GuildReply.Guild.Rank> getSortedRanksFromGuild(GuildReply guild) {
         return guild.getGuild().getRanks().stream()
             .sorted((o1, o2) -> o2.getPriority() - o1.getPriority())

--- a/src/main/java/com/senither/hypixel/contracts/rank/RankRequirementChecker.java
+++ b/src/main/java/com/senither/hypixel/contracts/rank/RankRequirementChecker.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.contracts.rank;
+
+import com.senither.hypixel.database.controller.GuildController;
+import net.hypixel.api.reply.GuildReply;
+import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public abstract class RankRequirementChecker {
+
+    public GuildReply.Guild.Rank getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
+        throw new UnsupportedOperationException("Getting rank for the given user is not supported by this requirement type!");
+    }
+
+    protected final List<GuildReply.Guild.Rank> getSortedRanksFromGuild(GuildReply guild) {
+        return guild.getGuild().getRanks().stream()
+            .sorted((o1, o2) -> o2.getPriority() - o1.getPriority())
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/senither/hypixel/database/DatabaseManager.java
+++ b/src/main/java/com/senither/hypixel/database/DatabaseManager.java
@@ -59,6 +59,7 @@ public class DatabaseManager {
             migrationManager.register(new AddDefaultRoleColumnToGuildsTableMigration());
             migrationManager.register(new AddAutoRenameColumnToGuildsTableMigration());
             migrationManager.register(new AddLastUpdatedAtColumnToProfileAndPlayerTableMigration());
+            migrationManager.register(new AddRankRequirementsColumnToGuildsTableMigration());
 
             log.info("Running database migrations");
             migrationManager.migrate();

--- a/src/main/java/com/senither/hypixel/database/controller/GuildController.java
+++ b/src/main/java/com/senither/hypixel/database/controller/GuildController.java
@@ -149,17 +149,17 @@ public class GuildController {
 
         public class RankRequirement {
 
-            private int fairySouls = 0;
-            private int talismansLegendary = 0;
-            private int talismansEpic = 0;
-            private int averageSkills = 0;
-            private int slayerExperience = 0;
+            private int fairySouls = Integer.MAX_VALUE;
+            private int talismansLegendary = Integer.MAX_VALUE;
+            private int talismansEpic = Integer.MAX_VALUE;
+            private int averageSkills = Integer.MAX_VALUE;
+            private int slayerExperience = Integer.MAX_VALUE;
             private PowerOrb powerOrb = null;
 
-            private int weaponPoints = 0;
+            private int weaponPoints = Integer.MAX_VALUE;
             private HashMap<String, Integer> weaponItems = new LinkedHashMap<>();
 
-            private int armorPoints = 0;
+            private int armorPoints = Integer.MAX_VALUE;
             private HashMap<String, Integer> armorItems = new LinkedHashMap<>();
 
             RankRequirement(JsonObject object) {
@@ -239,8 +239,11 @@ public class GuildController {
             }
 
             private int loadIntegerFromObject(JsonObject object, String type, String property) {
-                JsonObject jsonProperty = object.get(type).getAsJsonObject();
+                if (!object.has(type)) {
+                    return Integer.MAX_VALUE;
+                }
 
+                JsonObject jsonProperty = object.get(type).getAsJsonObject();
                 return jsonProperty.has(property) ? jsonProperty.get(property).getAsInt() : 0;
             }
         }

--- a/src/main/java/com/senither/hypixel/database/controller/GuildController.java
+++ b/src/main/java/com/senither/hypixel/database/controller/GuildController.java
@@ -159,6 +159,9 @@ public class GuildController {
             private int weaponPoints = 0;
             private HashMap<String, Integer> weaponItems = new LinkedHashMap<>();
 
+            private int armorPoints = 0;
+            private HashMap<String, Integer> armorItems = new LinkedHashMap<>();
+
             RankRequirement(JsonObject object) {
                 if (object.has("TALISMANS")) {
                     JsonObject talismans = object.get("TALISMANS").getAsJsonObject();
@@ -175,6 +178,17 @@ public class GuildController {
                     JsonObject items = weapons.get("items").getAsJsonObject();
                     for (String name : items.keySet()) {
                         weaponItems.put(name, items.get(name).getAsInt());
+                    }
+                }
+
+                if (object.has("ARMOR")) {
+                    JsonObject weapons = object.get("ARMOR").getAsJsonObject();
+
+                    this.armorPoints = weapons.get("points").getAsInt();
+
+                    JsonObject items = weapons.get("items").getAsJsonObject();
+                    for (String name : items.keySet()) {
+                        armorItems.put(name, items.get(name).getAsInt());
                     }
                 }
 
@@ -214,6 +228,14 @@ public class GuildController {
 
             public HashMap<String, Integer> getWeaponItems() {
                 return weaponItems;
+            }
+
+            public int getArmorPoints() {
+                return armorPoints;
+            }
+
+            public HashMap<String, Integer> getArmorItems() {
+                return armorItems;
             }
 
             private int loadIntegerFromObject(JsonObject object, String type, String property) {

--- a/src/main/java/com/senither/hypixel/database/controller/GuildController.java
+++ b/src/main/java/com/senither/hypixel/database/controller/GuildController.java
@@ -148,6 +148,7 @@ public class GuildController {
 
         public class RankRequirement {
 
+            private int fairySouls = 0;
             private int talismansLegendary = 0;
             private int talismansEpic = 0;
             private int averageSkills = 0;
@@ -179,6 +180,16 @@ public class GuildController {
 
                     this.slayerExperience = experience.has("experience") ? experience.get("experience").getAsInt() : 0;
                 }
+
+                if (object.has("FAIRY_SOULS")) {
+                    JsonObject fairySouls = object.get("FAIRY_SOULS").getAsJsonObject();
+
+                    this.fairySouls = fairySouls.has("amount") ? fairySouls.get("amount").getAsInt() : 0;
+                }
+            }
+
+            public int getFairySouls() {
+                return fairySouls;
             }
 
             public int getTalismansLegendary() {

--- a/src/main/java/com/senither/hypixel/database/controller/GuildController.java
+++ b/src/main/java/com/senither/hypixel/database/controller/GuildController.java
@@ -88,6 +88,10 @@ public class GuildController {
         cache.invalidate(guildId);
     }
 
+    public static GuildEntry.RankRequirement createEmptyRankRequirement() {
+        return new GuildEntry.RankRequirement();
+    }
+
     public static class GuildEntry {
 
         private final String id;
@@ -147,7 +151,7 @@ public class GuildController {
             return rankRequirements;
         }
 
-        public class RankRequirement {
+        public static class RankRequirement {
 
             private int fairySouls = Integer.MAX_VALUE;
             private int talismansLegendary = Integer.MAX_VALUE;
@@ -162,89 +166,123 @@ public class GuildController {
             private int armorPoints = Integer.MAX_VALUE;
             private HashMap<String, Integer> armorItems = new LinkedHashMap<>();
 
+            public RankRequirement() {
+                //
+            }
+
             RankRequirement(JsonObject object) {
-                if (object.has("TALISMANS")) {
-                    JsonObject talismans = object.get("TALISMANS").getAsJsonObject();
+                this.armorPoints = loadIntegerFromObject(object, "armorPoints");
+                this.armorItems = loadItemsFromObject(object, "armorItems");
 
-                    this.talismansLegendary = talismans.has("legendary") ? talismans.get("legendary").getAsInt() : 0;
-                    this.talismansEpic = talismans.has("epic") ? talismans.get("epic").getAsInt() : 0;
-                }
+                this.weaponPoints = loadIntegerFromObject(object, "weaponPoints");
+                this.weaponItems = loadItemsFromObject(object, "weaponItems");
 
-                if (object.has("WEAPONS")) {
-                    JsonObject weapons = object.get("WEAPONS").getAsJsonObject();
+                this.talismansLegendary = loadIntegerFromObject(object, "talismansLegendary");
+                this.talismansEpic = loadIntegerFromObject(object, "talismansEpic");
 
-                    this.weaponPoints = weapons.get("points").getAsInt();
-
-                    JsonObject items = weapons.get("items").getAsJsonObject();
-                    for (String name : items.keySet()) {
-                        weaponItems.put(name, items.get(name).getAsInt());
-                    }
-                }
-
-                if (object.has("ARMOR")) {
-                    JsonObject weapons = object.get("ARMOR").getAsJsonObject();
-
-                    this.armorPoints = weapons.get("points").getAsInt();
-
-                    JsonObject items = weapons.get("items").getAsJsonObject();
-                    for (String name : items.keySet()) {
-                        armorItems.put(name, items.get(name).getAsInt());
-                    }
-                }
-
-                this.averageSkills = loadIntegerFromObject(object, "AVERAGE_SKILLS", "level");
-                this.slayerExperience = loadIntegerFromObject(object, "SLAYER", "experience");
-                this.fairySouls = loadIntegerFromObject(object, "FAIRY_SOULS", "amount");
-                this.powerOrb = PowerOrb.fromId(loadIntegerFromObject(object, "POWER_ORBS", "level"));
+                this.averageSkills = loadIntegerFromObject(object, "averageSkills");
+                this.fairySouls = loadIntegerFromObject(object, "fairySouls");
+                this.slayerExperience = loadIntegerFromObject(object, "slayerExperience");
+                this.powerOrb = PowerOrb.fromName(object.has("powerOrb") ? object.get("powerOrb").getAsString() : null);
             }
 
             public int getFairySouls() {
                 return fairySouls;
             }
 
+            public void setFairySouls(int fairySouls) {
+                this.fairySouls = fairySouls;
+            }
+
             public int getTalismansLegendary() {
                 return talismansLegendary;
+            }
+
+            public void setTalismansLegendary(int talismansLegendary) {
+                this.talismansLegendary = talismansLegendary;
             }
 
             public int getTalismansEpic() {
                 return talismansEpic;
             }
 
+            public void setTalismansEpic(int talismansEpic) {
+                this.talismansEpic = talismansEpic;
+            }
+
             public int getAverageSkills() {
                 return averageSkills;
+            }
+
+            public void setAverageSkills(int averageSkills) {
+                this.averageSkills = averageSkills;
             }
 
             public int getSlayerExperience() {
                 return slayerExperience;
             }
 
+            public void setSlayerExperience(int slayerExperience) {
+                this.slayerExperience = slayerExperience;
+            }
+
             public PowerOrb getPowerOrb() {
                 return powerOrb;
+            }
+
+            public void setPowerOrb(PowerOrb powerOrb) {
+                this.powerOrb = powerOrb;
             }
 
             public int getWeaponPoints() {
                 return weaponPoints;
             }
 
+            public void setWeaponPoints(int weaponPoints) {
+                this.weaponPoints = weaponPoints;
+            }
+
             public HashMap<String, Integer> getWeaponItems() {
                 return weaponItems;
+            }
+
+            public void setWeaponItems(HashMap<String, Integer> weaponItems) {
+                this.weaponItems = weaponItems;
             }
 
             public int getArmorPoints() {
                 return armorPoints;
             }
 
+            public void setArmorPoints(int armorPoints) {
+                this.armorPoints = armorPoints;
+            }
+
             public HashMap<String, Integer> getArmorItems() {
                 return armorItems;
             }
 
-            private int loadIntegerFromObject(JsonObject object, String type, String property) {
-                if (!object.has(type)) {
-                    return Integer.MAX_VALUE;
+            public void setArmorItems(HashMap<String, Integer> armorItems) {
+                this.armorItems = armorItems;
+            }
+
+            private int loadIntegerFromObject(JsonObject object, String property) {
+                return object.has(property) ? object.get(property).getAsInt() : Integer.MAX_VALUE;
+            }
+
+            private HashMap<String, Integer> loadItemsFromObject(JsonObject object, String property) {
+                if (!object.has(property)) {
+                    return new HashMap<>();
                 }
 
-                JsonObject jsonProperty = object.get(type).getAsJsonObject();
-                return jsonProperty.has(property) ? jsonProperty.get(property).getAsInt() : 0;
+                JsonObject items = object.get(property).getAsJsonObject();
+                HashMap<String, Integer> map = new HashMap<>();
+
+                for (String name : items.keySet()) {
+                    map.put(name, items.get(name).getAsInt());
+                }
+
+                return map;
             }
         }
     }

--- a/src/main/java/com/senither/hypixel/database/controller/GuildController.java
+++ b/src/main/java/com/senither/hypixel/database/controller/GuildController.java
@@ -155,7 +155,7 @@ public class GuildController {
             private int slayerExperience = 0;
             private PowerOrb powerOrb = null;
 
-            public RankRequirement(JsonObject object) {
+            RankRequirement(JsonObject object) {
                 if (object.has("TALISMANS")) {
                     JsonObject talismans = object.get("TALISMANS").getAsJsonObject();
 
@@ -163,29 +163,10 @@ public class GuildController {
                     this.talismansEpic = talismans.has("epic") ? talismans.get("epic").getAsInt() : 0;
                 }
 
-                if (object.has("AVERAGE_SKILLS")) {
-                    JsonObject averageSkills = object.get("AVERAGE_SKILLS").getAsJsonObject();
-
-                    this.averageSkills = averageSkills.has("level") ? averageSkills.get("level").getAsInt() : 0;
-                }
-
-                if (object.has("POWER_ORBS")) {
-                    JsonObject powerOrbs = object.get("POWER_ORBS").getAsJsonObject();
-
-                    this.powerOrb = PowerOrb.fromId(powerOrbs.has("level") ? powerOrbs.get("level").getAsInt() : 0);
-                }
-
-                if (object.has("SLAYER")) {
-                    JsonObject experience = object.get("SLAYER").getAsJsonObject();
-
-                    this.slayerExperience = experience.has("experience") ? experience.get("experience").getAsInt() : 0;
-                }
-
-                if (object.has("FAIRY_SOULS")) {
-                    JsonObject fairySouls = object.get("FAIRY_SOULS").getAsJsonObject();
-
-                    this.fairySouls = fairySouls.has("amount") ? fairySouls.get("amount").getAsInt() : 0;
-                }
+                this.averageSkills = loadIntegerFromObject(object, "AVERAGE_SKILLS", "level");
+                this.slayerExperience = loadIntegerFromObject(object, "SLAYER", "experience");
+                this.fairySouls = loadIntegerFromObject(object, "FAIRY_SOULS", "amount");
+                this.powerOrb = PowerOrb.fromId(loadIntegerFromObject(object, "POWER_ORBS", "level"));
             }
 
             public int getFairySouls() {
@@ -210,6 +191,12 @@ public class GuildController {
 
             public PowerOrb getPowerOrb() {
                 return powerOrb;
+            }
+
+            private int loadIntegerFromObject(JsonObject object, String type, String property) {
+                JsonObject jsonProperty = object.get(type).getAsJsonObject();
+
+                return jsonProperty.has(property) ? jsonProperty.get(property).getAsInt() : 0;
             }
         }
     }

--- a/src/main/java/com/senither/hypixel/database/controller/GuildController.java
+++ b/src/main/java/com/senither/hypixel/database/controller/GuildController.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -155,12 +156,26 @@ public class GuildController {
             private int slayerExperience = 0;
             private PowerOrb powerOrb = null;
 
+            private int weaponPoints = 0;
+            private HashMap<String, Integer> weaponItems = new LinkedHashMap<>();
+
             RankRequirement(JsonObject object) {
                 if (object.has("TALISMANS")) {
                     JsonObject talismans = object.get("TALISMANS").getAsJsonObject();
 
                     this.talismansLegendary = talismans.has("legendary") ? talismans.get("legendary").getAsInt() : 0;
                     this.talismansEpic = talismans.has("epic") ? talismans.get("epic").getAsInt() : 0;
+                }
+
+                if (object.has("WEAPONS")) {
+                    JsonObject weapons = object.get("WEAPONS").getAsJsonObject();
+
+                    this.weaponPoints = weapons.get("points").getAsInt();
+
+                    JsonObject items = weapons.get("items").getAsJsonObject();
+                    for (String name : items.keySet()) {
+                        weaponItems.put(name, items.get(name).getAsInt());
+                    }
                 }
 
                 this.averageSkills = loadIntegerFromObject(object, "AVERAGE_SKILLS", "level");
@@ -191,6 +206,14 @@ public class GuildController {
 
             public PowerOrb getPowerOrb() {
                 return powerOrb;
+            }
+
+            public int getWeaponPoints() {
+                return weaponPoints;
+            }
+
+            public HashMap<String, Integer> getWeaponItems() {
+                return weaponItems;
             }
 
             private int loadIntegerFromObject(JsonObject object, String type, String property) {

--- a/src/main/java/com/senither/hypixel/database/migrations/AddRankRequirementsColumnToGuildsTableMigration.java
+++ b/src/main/java/com/senither/hypixel/database/migrations/AddRankRequirementsColumnToGuildsTableMigration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.database.migrations;
+
+import com.senither.hypixel.contracts.database.Migration;
+import com.senither.hypixel.database.DatabaseManager;
+
+import java.sql.SQLException;
+
+public class AddRankRequirementsColumnToGuildsTableMigration implements Migration {
+
+    @Override
+    public boolean up(DatabaseManager databaseManager) throws SQLException {
+        return databaseManager.queryUpdate(
+            "ALTER TABLE `guilds` ADD `rank_requirements` TEXT NULL AFTER `auto_rename`;"
+        );
+    }
+
+    @Override
+    public boolean down(DatabaseManager databaseManager) throws SQLException {
+        return databaseManager.queryUpdate(
+            "ALTER TABLE `guilds` DROP `rank_requirements`;"
+        );
+    }
+}

--- a/src/main/java/com/senither/hypixel/rank/RankCheckResponse.java
+++ b/src/main/java/com/senither/hypixel/rank/RankCheckResponse.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank;
+
+import net.hypixel.api.reply.GuildReply;
+
+import java.util.HashMap;
+
+public class RankCheckResponse {
+
+    private final GuildReply.Guild.Rank rank;
+    private final HashMap<String, Object> metric;
+
+    public RankCheckResponse(GuildReply.Guild.Rank rank, HashMap<String, Object> metric) {
+        this.rank = rank;
+        this.metric = metric;
+    }
+
+    public GuildReply.Guild.Rank getRank() {
+        return rank;
+    }
+
+    public HashMap<String, Object> getMetric() {
+        return metric;
+    }
+}

--- a/src/main/java/com/senither/hypixel/rank/RankRequirementType.java
+++ b/src/main/java/com/senither/hypixel/rank/RankRequirementType.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank;
+
+import com.senither.hypixel.contracts.rank.RankRequirementChecker;
+import com.senither.hypixel.rank.checkers.*;
+
+public enum RankRequirementType {
+
+    TALISMANS("Talismans", new TalismansChecker()),
+    AVERAGE_SKILLS("Average Skills", new AverageSkillsChecker()),
+    ARMOR("Armor", new ArmorChecker()),
+    POWER_ORBS("Power Orbs", new PowerOrbsChecker()),
+    SLAYER("Slayer", new SlayerChecker()),
+    WEAPONS("Weapons", new WeaponsChecker());
+
+    private final String name;
+    private final RankRequirementChecker checker;
+
+    RankRequirementType(String name, RankRequirementChecker checker) {
+        this.name = name;
+        this.checker = checker;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public RankRequirementChecker getChecker() {
+        return checker;
+    }
+}

--- a/src/main/java/com/senither/hypixel/rank/RankRequirementType.java
+++ b/src/main/java/com/senither/hypixel/rank/RankRequirementType.java
@@ -29,7 +29,9 @@ import com.senither.hypixel.rank.handler.CustomObjectValueHandler;
 import com.senither.hypixel.rank.handler.DoubleObjectValueHandler;
 import com.senither.hypixel.rank.handler.IntegerValueHandler;
 import com.senither.hypixel.rank.handler.ItemValueHandler;
+import com.senither.hypixel.rank.items.Armor;
 import com.senither.hypixel.rank.items.PowerOrb;
+import com.senither.hypixel.rank.items.Weapon;
 import com.senither.hypixel.utils.NumberUtil;
 
 public enum RankRequirementType {
@@ -54,12 +56,14 @@ public enum RankRequirementType {
     )),
     ARMOR("Armor", new ArmorChecker(), new ItemValueHandler(
         GuildController.GuildEntry.RankRequirement::setArmorPoints,
-        GuildController.GuildEntry.RankRequirement::getArmorItems
+        GuildController.GuildEntry.RankRequirement::getArmorItems,
+        Armor.values()
     )),
-    WEAPONS("Weapons", new WeaponsChecker(), new ItemValueHandler(
+    WEAPONS("Weapon", new WeaponsChecker(), new ItemValueHandler(
         GuildController.GuildEntry.RankRequirement::setWeaponPoints,
-        GuildController.GuildEntry.RankRequirement::getWeaponItems
-    ));
+        GuildController.GuildEntry.RankRequirement::getWeaponItems,
+        Weapon.values())
+    );
 
     private final String name;
     private final RankRequirementChecker checker;

--- a/src/main/java/com/senither/hypixel/rank/RankRequirementType.java
+++ b/src/main/java/com/senither/hypixel/rank/RankRequirementType.java
@@ -31,7 +31,8 @@ public enum RankRequirementType {
     ARMOR("Armor", new ArmorChecker()),
     POWER_ORBS("Power Orbs", new PowerOrbsChecker()),
     SLAYER("Slayer", new SlayerChecker()),
-    WEAPONS("Weapons", new WeaponsChecker());
+    WEAPONS("Weapons", new WeaponsChecker()),
+    FAIRY_SOULS("Fairy Souls", new FairySoulsChecker());
 
     private final String name;
     private final RankRequirementChecker checker;

--- a/src/main/java/com/senither/hypixel/rank/RankRequirementType.java
+++ b/src/main/java/com/senither/hypixel/rank/RankRequirementType.java
@@ -21,25 +21,56 @@
 
 package com.senither.hypixel.rank;
 
+import com.senither.hypixel.contracts.rank.RankCommandHandler;
 import com.senither.hypixel.contracts.rank.RankRequirementChecker;
+import com.senither.hypixel.database.controller.GuildController;
 import com.senither.hypixel.rank.checkers.*;
+import com.senither.hypixel.rank.handler.CustomObjectValueHandler;
+import com.senither.hypixel.rank.handler.DoubleObjectValueHandler;
+import com.senither.hypixel.rank.handler.IntegerValueHandler;
+import com.senither.hypixel.rank.handler.ItemValueHandler;
+import com.senither.hypixel.rank.items.PowerOrb;
+import com.senither.hypixel.utils.NumberUtil;
 
 public enum RankRequirementType {
 
-    TALISMANS("Talismans", new TalismansChecker()),
-    AVERAGE_SKILLS("Average Skills", new AverageSkillsChecker()),
-    ARMOR("Armor", new ArmorChecker()),
-    POWER_ORBS("Power Orbs", new PowerOrbsChecker()),
-    SLAYER("Slayer", new SlayerChecker()),
-    WEAPONS("Weapons", new WeaponsChecker()),
-    FAIRY_SOULS("Fairy Souls", new FairySoulsChecker());
+    TALISMANS("Talismans", new TalismansChecker(), new DoubleObjectValueHandler(
+        GuildController.GuildEntry.RankRequirement::setTalismansLegendary,
+        GuildController.GuildEntry.RankRequirement::setTalismansEpic,
+        "The new Talismans requirement for **:rank** have successfully been set to **:first** legendaries, and **:second** epics."
+    )),
+    AVERAGE_SKILLS("Average Skills", new AverageSkillsChecker(), new IntegerValueHandler(
+        GuildController.GuildEntry.RankRequirement::setAverageSkills
+    )),
+    SLAYER("Slayer XP", new SlayerChecker(), new IntegerValueHandler(
+        GuildController.GuildEntry.RankRequirement::setSlayerExperience
+    )),
+    FAIRY_SOULS("Fairy Souls", new FairySoulsChecker(), new IntegerValueHandler(
+        GuildController.GuildEntry.RankRequirement::setFairySouls
+    )),
+    POWER_ORBS("Power Orbs", new PowerOrbsChecker(), new CustomObjectValueHandler<>(
+        value -> PowerOrb.fromId(NumberUtil.parseInt(value.toString(), -1)),
+        GuildController.GuildEntry.RankRequirement::setPowerOrb
+    )),
+    ARMOR("Armor", new ArmorChecker(), new ItemValueHandler(
+        GuildController.GuildEntry.RankRequirement::setArmorPoints,
+        GuildController.GuildEntry.RankRequirement::getArmorItems
+    )),
+    WEAPONS("Weapons", new WeaponsChecker(), new ItemValueHandler(
+        GuildController.GuildEntry.RankRequirement::setWeaponPoints,
+        GuildController.GuildEntry.RankRequirement::getWeaponItems
+    ));
 
     private final String name;
     private final RankRequirementChecker checker;
+    private final RankCommandHandler handler;
 
-    RankRequirementType(String name, RankRequirementChecker checker) {
+    RankRequirementType(String name, RankRequirementChecker checker, RankCommandHandler handler) {
         this.name = name;
         this.checker = checker;
+        this.handler = handler;
+
+        this.handler.setRankType(this);
     }
 
     public String getName() {
@@ -48,5 +79,9 @@ public enum RankRequirementType {
 
     public RankRequirementChecker getChecker() {
         return checker;
+    }
+
+    public RankCommandHandler getHandler() {
+        return handler;
     }
 }

--- a/src/main/java/com/senither/hypixel/rank/checkers/ArmorChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/ArmorChecker.java
@@ -27,6 +27,7 @@ import com.senither.hypixel.database.controller.GuildController;
 import com.senither.hypixel.exceptions.FriendlyException;
 import com.senither.hypixel.inventory.Item;
 import com.senither.hypixel.inventory.ItemType;
+import com.senither.hypixel.rank.RankCheckResponse;
 import com.senither.hypixel.rank.items.Armor;
 import com.senither.hypixel.rank.items.ArmorSet;
 import net.hypixel.api.reply.GuildReply;
@@ -38,7 +39,7 @@ import java.util.*;
 public class ArmorChecker extends RankRequirementChecker {
 
     @Override
-    public GuildReply.Guild.Rank getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
+    public RankCheckResponse getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
         JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
 
         if (!isInventoryApiEnabled(member)) {
@@ -86,13 +87,19 @@ public class ArmorChecker extends RankRequirementChecker {
                 }
 
                 if (points >= requirement.getWeaponPoints()) {
-                    return rank;
+                    return createResponse(rank, points);
                 }
             }
         } catch (IOException ignored) {
             ignored.printStackTrace();
         }
-        return null;
+        return createResponse(null, 0);
+    }
+
+    private RankCheckResponse createResponse(GuildReply.Guild.Rank rank, int points) {
+        return new RankCheckResponse(rank, new HashMap<String, Object>() {{
+            put("points", points);
+        }});
     }
 
     private boolean isInventoryApiEnabled(JsonObject json) {

--- a/src/main/java/com/senither/hypixel/rank/checkers/ArmorChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/ArmorChecker.java
@@ -21,8 +21,80 @@
 
 package com.senither.hypixel.rank.checkers;
 
+import com.google.gson.JsonObject;
 import com.senither.hypixel.contracts.rank.RankRequirementChecker;
+import com.senither.hypixel.database.controller.GuildController;
+import com.senither.hypixel.exceptions.FriendlyException;
+import com.senither.hypixel.inventory.Item;
+import com.senither.hypixel.inventory.ItemType;
+import com.senither.hypixel.rank.items.Armor;
+import com.senither.hypixel.rank.items.ArmorSet;
+import net.hypixel.api.reply.GuildReply;
+import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
+
+import java.io.IOException;
+import java.util.*;
 
 public class ArmorChecker extends RankRequirementChecker {
 
+    @Override
+    public GuildReply.Guild.Rank getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
+        JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
+
+        if (!isInventoryApiEnabled(member)) {
+            throw new FriendlyException("Inventory API is disabled, unable to look for armor");
+        }
+
+        try {
+            List<Item> items = new ArrayList<>();
+            items.addAll(buildInventoryForPlayer(member, "ender_chest_contents").getItemsWithType(ItemType.ARMOR));
+            items.addAll(buildInventoryForPlayer(member, "inv_contents").getItemsWithType(ItemType.ARMOR));
+            items.addAll(buildInventoryForPlayer(member, "inv_armor").getItemsWithType(ItemType.ARMOR));
+
+            for (GuildReply.Guild.Rank rank : getSortedRanksFromGuild(guildReply)) {
+                if (!guildEntry.getRankRequirements().containsKey(rank.getName())) {
+                    continue;
+                }
+
+                EnumMap<Armor, Integer> armors = new EnumMap<>(Armor.class);
+                GuildController.GuildEntry.RankRequirement requirement = guildEntry.getRankRequirements().get(rank.getName());
+
+                for (Map.Entry<String, Integer> armorEntry : requirement.getArmorItems().entrySet()) {
+                    Armor armor = Armor.getFromName(armorEntry.getKey());
+                    if (armor != null) {
+                        armors.put(armor, armorEntry.getValue());
+                    }
+                }
+
+                int points = 0;
+                for (Map.Entry<Armor, Integer> armorIntegerEntry : armors.entrySet()) {
+                    int armorPieces = 0;
+
+                    ArmorSet armorSet = armorIntegerEntry.getKey().getArmorSet();
+                    for (Item item : items) {
+                        if (armorSet.isPartOfSet(item.getName())) {
+                            armorPieces += armorIntegerEntry.getValue();
+                        }
+                    }
+
+                    if (armorPieces > armorSet.getSetPieces()) {
+                        points += armorIntegerEntry.getValue();
+                    }
+                }
+
+                if (points >= requirement.getWeaponPoints()) {
+                    return rank;
+                }
+            }
+        } catch (IOException ignored) {
+            ignored.printStackTrace();
+        }
+        return null;
+    }
+
+    private boolean isInventoryApiEnabled(JsonObject json) {
+        return json.has("ender_chest_contents")
+            && json.has("inv_contents")
+            && json.has("inv_armor");
+    }
 }

--- a/src/main/java/com/senither/hypixel/rank/checkers/ArmorChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/ArmorChecker.java
@@ -22,8 +22,6 @@
 package com.senither.hypixel.rank.checkers;
 
 import com.senither.hypixel.contracts.rank.RankRequirementChecker;
-import net.hypixel.api.reply.GuildReply;
-import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
 
 public class ArmorChecker extends RankRequirementChecker {
 

--- a/src/main/java/com/senither/hypixel/rank/checkers/ArmorChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/ArmorChecker.java
@@ -56,9 +56,12 @@ public class ArmorChecker extends RankRequirementChecker {
                     continue;
                 }
 
-                EnumMap<Armor, Integer> armors = new EnumMap<>(Armor.class);
                 GuildController.GuildEntry.RankRequirement requirement = guildEntry.getRankRequirements().get(rank.getName());
+                if (requirement.getArmorItems().isEmpty() || requirement.getArmorPoints() == Integer.MAX_VALUE) {
+                    continue;
+                }
 
+                EnumMap<Armor, Integer> armors = new EnumMap<>(Armor.class);
                 for (Map.Entry<String, Integer> armorEntry : requirement.getArmorItems().entrySet()) {
                     Armor armor = Armor.getFromName(armorEntry.getKey());
                     if (armor != null) {

--- a/src/main/java/com/senither/hypixel/rank/checkers/ArmorChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/ArmorChecker.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank.checkers;
+
+import com.senither.hypixel.contracts.rank.RankRequirementChecker;
+import net.hypixel.api.reply.GuildReply;
+import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
+
+public class ArmorChecker extends RankRequirementChecker {
+
+}

--- a/src/main/java/com/senither/hypixel/rank/checkers/ArmorChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/ArmorChecker.java
@@ -39,6 +39,22 @@ import java.util.*;
 public class ArmorChecker extends RankRequirementChecker {
 
     @Override
+    public String getRankRequirementNote(GuildController.GuildEntry.RankRequirement requirement) {
+        if (requirement.getArmorPoints() == Integer.MAX_VALUE || requirement.getArmorItems().isEmpty()) {
+            return "No Armor requirement";
+        }
+
+        List<String> items = new ArrayList<>();
+        for (Map.Entry<String, Integer> entry : requirement.getArmorItems().entrySet()) {
+            items.add(String.format("%s = %s", entry.getKey(), entry.getValue()));
+        }
+
+        return String.format("Must have %s Armor Points, Items:\n\n%s",
+            requirement.getArmorPoints(), String.join("\n", items)
+        );
+    }
+
+    @Override
     public RankCheckResponse getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
         JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
 

--- a/src/main/java/com/senither/hypixel/rank/checkers/AverageSkillsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/AverageSkillsChecker.java
@@ -63,7 +63,7 @@ public class AverageSkillsChecker extends RankRequirementChecker {
             throw new FriendlyException("Skills API is disabled, unable to calculate average skill level");
         }
 
-        double averageSkillLevel = Math.round((
+        double averageSkillLevel = (
             getSkillLevelFromExperience(mining) +
                 getSkillLevelFromExperience(foraging) +
                 getSkillLevelFromExperience(enchanting) +
@@ -71,7 +71,7 @@ public class AverageSkillsChecker extends RankRequirementChecker {
                 getSkillLevelFromExperience(combat) +
                 getSkillLevelFromExperience(fishing) +
                 getSkillLevelFromExperience(alchemy)
-        ) / 7D);
+        ) / 7D;
 
         for (GuildReply.Guild.Rank rank : getSortedRanksFromGuild(guildReply)) {
             if (!guildEntry.getRankRequirements().containsKey(rank.getName())) {
@@ -79,7 +79,7 @@ public class AverageSkillsChecker extends RankRequirementChecker {
             }
 
             GuildController.GuildEntry.RankRequirement requirement = guildEntry.getRankRequirements().get(rank.getName());
-            if (requirement.getAverageSkills() <= averageSkillLevel) {
+            if (requirement.getAverageSkills() <= Math.round(averageSkillLevel)) {
                 return createResponse(rank, averageSkillLevel);
             }
         }

--- a/src/main/java/com/senither/hypixel/rank/checkers/AverageSkillsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/AverageSkillsChecker.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank.checkers;
+
+import com.senither.hypixel.contracts.rank.RankRequirementChecker;
+
+public class AverageSkillsChecker extends RankRequirementChecker {
+
+}

--- a/src/main/java/com/senither/hypixel/rank/checkers/AverageSkillsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/AverageSkillsChecker.java
@@ -65,7 +65,7 @@ public class AverageSkillsChecker extends RankRequirementChecker {
             throw new FriendlyException("Skills API is disabled, unable to calculate average skill level");
         }
 
-        double averageSkillLevel = (
+        double averageSkillLevel = Math.round((
             getSkillLevelFromExperience(mining) +
                 getSkillLevelFromExperience(foraging) +
                 getSkillLevelFromExperience(enchanting) +
@@ -73,7 +73,7 @@ public class AverageSkillsChecker extends RankRequirementChecker {
                 getSkillLevelFromExperience(combat) +
                 getSkillLevelFromExperience(fishing) +
                 getSkillLevelFromExperience(alchemy)
-        ) / 7D;
+        ) / 7D);
 
         for (GuildReply.Guild.Rank rank : getSortedRanksFromGuild(guildReply)) {
             if (!guildEntry.getRankRequirements().containsKey(rank.getName())) {

--- a/src/main/java/com/senither/hypixel/rank/checkers/AverageSkillsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/AverageSkillsChecker.java
@@ -25,13 +25,11 @@ import com.google.gson.JsonObject;
 import com.senither.hypixel.contracts.rank.RankRequirementChecker;
 import com.senither.hypixel.database.controller.GuildController;
 import com.senither.hypixel.exceptions.FriendlyException;
+import com.senither.hypixel.rank.RankCheckResponse;
 import net.hypixel.api.reply.GuildReply;
 import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 public class AverageSkillsChecker extends RankRequirementChecker {
 
@@ -50,7 +48,7 @@ public class AverageSkillsChecker extends RankRequirementChecker {
     }
 
     @Override
-    public GuildReply.Guild.Rank getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
+    public RankCheckResponse getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
         JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
 
         double mining = getSkillExperience(member, "experience_skill_mining");
@@ -82,10 +80,16 @@ public class AverageSkillsChecker extends RankRequirementChecker {
 
             GuildController.GuildEntry.RankRequirement requirement = guildEntry.getRankRequirements().get(rank.getName());
             if (requirement.getAverageSkills() <= averageSkillLevel) {
-                return rank;
+                return createResponse(rank, averageSkillLevel);
             }
         }
-        return null;
+        return createResponse(null, averageSkillLevel);
+    }
+
+    private RankCheckResponse createResponse(GuildReply.Guild.Rank rank, double amount) {
+        return new RankCheckResponse(rank, new HashMap<String, Object>() {{
+            put("amount", amount);
+        }});
     }
 
     private double getSkillLevelFromExperience(double experience) {

--- a/src/main/java/com/senither/hypixel/rank/checkers/AverageSkillsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/AverageSkillsChecker.java
@@ -48,6 +48,14 @@ public class AverageSkillsChecker extends RankRequirementChecker {
     }
 
     @Override
+    public String getRankRequirementNote(GuildController.GuildEntry.RankRequirement requirement) {
+        if (requirement.getAverageSkills() == Integer.MAX_VALUE) {
+            return "No Average Skill requirement";
+        }
+        return String.format("Must have %s Average Skill", requirement.getAverageSkills());
+    }
+
+    @Override
     public RankCheckResponse getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
         JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
 

--- a/src/main/java/com/senither/hypixel/rank/checkers/FairySoulsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/FairySoulsChecker.java
@@ -34,6 +34,14 @@ import java.util.UUID;
 public class FairySoulsChecker extends RankRequirementChecker {
 
     @Override
+    public String getRankRequirementNote(GuildController.GuildEntry.RankRequirement requirement) {
+        if (requirement.getFairySouls() == Integer.MAX_VALUE) {
+            return "No Fairy Soul requirement";
+        }
+        return String.format("%s Minimum Fairy Souls", requirement.getFairySouls());
+    }
+
+    @Override
     public RankCheckResponse getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
         JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
 

--- a/src/main/java/com/senither/hypixel/rank/checkers/FairySoulsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/FairySoulsChecker.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank.checkers;
+
+import com.google.gson.JsonObject;
+import com.senither.hypixel.contracts.rank.RankRequirementChecker;
+import com.senither.hypixel.database.controller.GuildController;
+import net.hypixel.api.reply.GuildReply;
+import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
+
+import java.util.UUID;
+
+public class FairySoulsChecker extends RankRequirementChecker {
+
+    @Override
+    public GuildReply.Guild.Rank getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
+        JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
+
+        int collectedFairySouls = member.get("fairy_souls_collected").getAsInt();
+
+        for (GuildReply.Guild.Rank rank : getSortedRanksFromGuild(guildReply)) {
+            if (!guildEntry.getRankRequirements().containsKey(rank.getName())) {
+                continue;
+            }
+
+            GuildController.GuildEntry.RankRequirement requirement = guildEntry.getRankRequirements().get(rank.getName());
+            if (requirement.getFairySouls() <= collectedFairySouls) {
+                return rank;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/senither/hypixel/rank/checkers/FairySoulsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/FairySoulsChecker.java
@@ -24,15 +24,17 @@ package com.senither.hypixel.rank.checkers;
 import com.google.gson.JsonObject;
 import com.senither.hypixel.contracts.rank.RankRequirementChecker;
 import com.senither.hypixel.database.controller.GuildController;
+import com.senither.hypixel.rank.RankCheckResponse;
 import net.hypixel.api.reply.GuildReply;
 import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
 
+import java.util.HashMap;
 import java.util.UUID;
 
 public class FairySoulsChecker extends RankRequirementChecker {
 
     @Override
-    public GuildReply.Guild.Rank getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
+    public RankCheckResponse getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
         JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
 
         int collectedFairySouls = member.get("fairy_souls_collected").getAsInt();
@@ -44,9 +46,15 @@ public class FairySoulsChecker extends RankRequirementChecker {
 
             GuildController.GuildEntry.RankRequirement requirement = guildEntry.getRankRequirements().get(rank.getName());
             if (requirement.getFairySouls() <= collectedFairySouls) {
-                return rank;
+                return createResponse(rank, collectedFairySouls);
             }
         }
-        return null;
+        return createResponse(null, collectedFairySouls);
+    }
+
+    private RankCheckResponse createResponse(GuildReply.Guild.Rank rank, int amount) {
+        return new RankCheckResponse(rank, new HashMap<String, Object>() {{
+            put("amount", amount);
+        }});
     }
 }

--- a/src/main/java/com/senither/hypixel/rank/checkers/PowerOrbsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/PowerOrbsChecker.java
@@ -40,6 +40,14 @@ import java.util.UUID;
 public class PowerOrbsChecker extends RankRequirementChecker {
 
     @Override
+    public String getRankRequirementNote(GuildController.GuildEntry.RankRequirement requirement) {
+        if (requirement.getPowerOrb() == null) {
+            return "No Power Orb requirement";
+        }
+        return String.format("Must have at least %s ", requirement.getPowerOrb().getName());
+    }
+
+    @Override
     public RankCheckResponse getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
         JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
 

--- a/src/main/java/com/senither/hypixel/rank/checkers/PowerOrbsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/PowerOrbsChecker.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank.checkers;
+
+import com.senither.hypixel.contracts.rank.RankRequirementChecker;
+
+public class PowerOrbsChecker extends RankRequirementChecker {
+}

--- a/src/main/java/com/senither/hypixel/rank/checkers/PowerOrbsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/PowerOrbsChecker.java
@@ -26,19 +26,21 @@ import com.senither.hypixel.contracts.rank.RankRequirementChecker;
 import com.senither.hypixel.database.controller.GuildController;
 import com.senither.hypixel.exceptions.FriendlyException;
 import com.senither.hypixel.inventory.Item;
+import com.senither.hypixel.rank.RankCheckResponse;
 import com.senither.hypixel.rank.items.PowerOrb;
 import net.hypixel.api.reply.GuildReply;
 import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
 public class PowerOrbsChecker extends RankRequirementChecker {
 
     @Override
-    public GuildReply.Guild.Rank getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
+    public RankCheckResponse getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
         JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
 
         if (!isInventoryApiEnabled(member)) {
@@ -76,12 +78,19 @@ public class PowerOrbsChecker extends RankRequirementChecker {
 
                 GuildController.GuildEntry.RankRequirement requirement = guildEntry.getRankRequirements().get(rank.getName());
                 if (requirement.getPowerOrb() != null && requirement.getPowerOrb().getId() <= powerOrb.getId()) {
-                    return rank;
+                    return createResponse(rank, powerOrb);
                 }
             }
+            return createResponse(null, powerOrb);
         } catch (IOException ignored) {
         }
-        return null;
+        return createResponse(null, null);
+    }
+
+    private RankCheckResponse createResponse(GuildReply.Guild.Rank rank, PowerOrb powerOrb) {
+        return new RankCheckResponse(rank, new HashMap<String, Object>() {{
+            put("item", powerOrb);
+        }});
     }
 
     private boolean isInventoryApiEnabled(JsonObject json) {

--- a/src/main/java/com/senither/hypixel/rank/checkers/PowerOrbsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/PowerOrbsChecker.java
@@ -75,7 +75,7 @@ public class PowerOrbsChecker extends RankRequirementChecker {
                 }
 
                 GuildController.GuildEntry.RankRequirement requirement = guildEntry.getRankRequirements().get(rank.getName());
-                if (requirement.getPowerOrb().getId() <= powerOrb.getId()) {
+                if (requirement.getPowerOrb() != null && requirement.getPowerOrb().getId() <= powerOrb.getId()) {
                     return rank;
                 }
             }

--- a/src/main/java/com/senither/hypixel/rank/checkers/PowerOrbsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/PowerOrbsChecker.java
@@ -21,7 +21,71 @@
 
 package com.senither.hypixel.rank.checkers;
 
+import com.google.gson.JsonObject;
 import com.senither.hypixel.contracts.rank.RankRequirementChecker;
+import com.senither.hypixel.database.controller.GuildController;
+import com.senither.hypixel.exceptions.FriendlyException;
+import com.senither.hypixel.inventory.Item;
+import com.senither.hypixel.rank.items.PowerOrb;
+import net.hypixel.api.reply.GuildReply;
+import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 public class PowerOrbsChecker extends RankRequirementChecker {
+
+    @Override
+    public GuildReply.Guild.Rank getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
+        JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
+
+        if (!isInventoryApiEnabled(member)) {
+            throw new FriendlyException("Inventory API is disabled, unable to look for power orbs");
+        }
+
+        try {
+            List<Item> items = new ArrayList<>();
+            items.addAll(buildInventoryForPlayer(member, "ender_chest_contents").getItems());
+            items.addAll(buildInventoryForPlayer(member, "inv_contents").getItems());
+
+            PowerOrb powerOrb = null;
+            for (Item item : items) {
+                for (PowerOrb orb : PowerOrb.values()) {
+                    if (!item.getName().endsWith(orb.getName())) {
+                        continue;
+                    }
+
+                    if (powerOrb != null && powerOrb.getId() > orb.getId()) {
+                        continue;
+                    }
+
+                    powerOrb = orb;
+                }
+            }
+
+            if (powerOrb == null) {
+                return null;
+            }
+
+            for (GuildReply.Guild.Rank rank : getSortedRanksFromGuild(guildReply)) {
+                if (!guildEntry.getRankRequirements().containsKey(rank.getName())) {
+                    continue;
+                }
+
+                GuildController.GuildEntry.RankRequirement requirement = guildEntry.getRankRequirements().get(rank.getName());
+                if (requirement.getPowerOrb().getId() <= powerOrb.getId()) {
+                    return rank;
+                }
+            }
+        } catch (IOException ignored) {
+        }
+        return null;
+    }
+
+    private boolean isInventoryApiEnabled(JsonObject json) {
+        return json.has("ender_chest_contents")
+            && json.has("inv_contents");
+    }
 }

--- a/src/main/java/com/senither/hypixel/rank/checkers/SlayerChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/SlayerChecker.java
@@ -34,6 +34,14 @@ import java.util.UUID;
 public class SlayerChecker extends RankRequirementChecker {
 
     @Override
+    public String getRankRequirementNote(GuildController.GuildEntry.RankRequirement requirement) {
+        if (requirement.getSlayerExperience() == Integer.MAX_VALUE) {
+            return "No Slayer requirement";
+        }
+        return String.format("Must have %s Slayer XP", requirement.getSlayerExperience());
+    }
+
+    @Override
     public RankCheckResponse getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
         JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
 

--- a/src/main/java/com/senither/hypixel/rank/checkers/SlayerChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/SlayerChecker.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank.checkers;
+
+import com.senither.hypixel.contracts.rank.RankRequirementChecker;
+
+public class SlayerChecker extends RankRequirementChecker {
+}

--- a/src/main/java/com/senither/hypixel/rank/checkers/SlayerChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/SlayerChecker.java
@@ -24,15 +24,17 @@ package com.senither.hypixel.rank.checkers;
 import com.google.gson.JsonObject;
 import com.senither.hypixel.contracts.rank.RankRequirementChecker;
 import com.senither.hypixel.database.controller.GuildController;
+import com.senither.hypixel.rank.RankCheckResponse;
 import net.hypixel.api.reply.GuildReply;
 import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
 
+import java.util.HashMap;
 import java.util.UUID;
 
 public class SlayerChecker extends RankRequirementChecker {
 
     @Override
-    public GuildReply.Guild.Rank getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
+    public RankCheckResponse getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
         JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
 
         long totalExperience = 0;
@@ -51,9 +53,15 @@ public class SlayerChecker extends RankRequirementChecker {
 
             GuildController.GuildEntry.RankRequirement requirement = guildEntry.getRankRequirements().get(rank.getName());
             if (requirement.getSlayerExperience() <= totalExperience) {
-                return rank;
+                return createResponse(rank, totalExperience);
             }
         }
-        return null;
+        return createResponse(null, totalExperience);
+    }
+
+    private RankCheckResponse createResponse(GuildReply.Guild.Rank rank, long amount) {
+        return new RankCheckResponse(rank, new HashMap<String, Object>() {{
+            put("amount", amount);
+        }});
     }
 }

--- a/src/main/java/com/senither/hypixel/rank/checkers/TalismansChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/TalismansChecker.java
@@ -27,18 +27,20 @@ import com.senither.hypixel.database.controller.GuildController;
 import com.senither.hypixel.exceptions.FriendlyException;
 import com.senither.hypixel.inventory.Item;
 import com.senither.hypixel.inventory.ItemType;
+import com.senither.hypixel.rank.RankCheckResponse;
 import net.hypixel.api.reply.GuildReply;
 import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
 public class TalismansChecker extends RankRequirementChecker {
 
     @Override
-    public GuildReply.Guild.Rank getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
+    public RankCheckResponse getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
         JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
 
         if (!isInventoryApiEnabled(member)) {
@@ -72,12 +74,21 @@ public class TalismansChecker extends RankRequirementChecker {
 
                 GuildController.GuildEntry.RankRequirement requirement = guildEntry.getRankRequirements().get(rank.getName());
                 if (requirement.getTalismansLegendary() <= legendaries && requirement.getTalismansEpic() <= epics) {
-                    return rank;
+                    return createResponse(rank, legendaries, epics);
                 }
             }
+
+            return createResponse(null, legendaries, epics);
         } catch (IOException ignored) {
+            return null;
         }
-        return null;
+    }
+
+    private RankCheckResponse createResponse(GuildReply.Guild.Rank rank, int legendaries, int epics) {
+        return new RankCheckResponse(rank, new HashMap<String, Object>() {{
+            put("legendaries", legendaries);
+            put("epics", epics);
+        }});
     }
 
     private boolean isInventoryApiEnabled(JsonObject json) {

--- a/src/main/java/com/senither/hypixel/rank/checkers/TalismansChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/TalismansChecker.java
@@ -21,8 +21,75 @@
 
 package com.senither.hypixel.rank.checkers;
 
+import com.google.gson.JsonObject;
 import com.senither.hypixel.contracts.rank.RankRequirementChecker;
+import com.senither.hypixel.database.controller.GuildController;
+import com.senither.hypixel.exceptions.FriendlyException;
+import com.senither.hypixel.inventory.Inventory;
+import com.senither.hypixel.inventory.Item;
+import com.senither.hypixel.inventory.ItemType;
+import net.hypixel.api.reply.GuildReply;
+import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 public class TalismansChecker extends RankRequirementChecker {
 
+    @Override
+    public GuildReply.Guild.Rank getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
+        JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
+
+        if (!isInventoryApiEnabled(member)) {
+            throw new FriendlyException("Inventory API is disabled, unable to look for talismans");
+        }
+
+        try {
+            List<Item> talismans = new ArrayList<>();
+            talismans.addAll(getTalismansFromInventory(member, "ender_chest_contents"));
+            talismans.addAll(getTalismansFromInventory(member, "talisman_bag"));
+            talismans.addAll(getTalismansFromInventory(member, "inv_contents"));
+
+            int epics = 0;
+            int legendaries = 0;
+
+            for (Item talisman : talismans) {
+                switch (talisman.getRarity()) {
+                    case LEGENDARY:
+                        legendaries++;
+                        break;
+                    case EPIC:
+                        epics++;
+                        break;
+                }
+            }
+
+            for (GuildReply.Guild.Rank rank : getSortedRanksFromGuild(guildReply)) {
+                if (!guildEntry.getRankRequirements().containsKey(rank.getName())) {
+                    continue;
+                }
+
+                GuildController.GuildEntry.RankRequirement requirement = guildEntry.getRankRequirements().get(rank.getName());
+                if (requirement.getTalismansLegendary() <= legendaries && requirement.getTalismansEpic() <= epics) {
+                    return rank;
+                }
+            }
+        } catch (IOException ignored) {
+        }
+        return null;
+    }
+
+    private List<Item> getTalismansFromInventory(JsonObject member, String inventoryName) throws IOException {
+        Inventory inventory = new Inventory(member.get(inventoryName).getAsJsonObject().get("data").getAsString());
+
+        return inventory.getItemsWithType(ItemType.ACCESSORY);
+    }
+
+    private boolean isInventoryApiEnabled(JsonObject json) {
+        return json.has("ender_chest_contents")
+            && json.has("talisman_bag")
+            && json.has("inv_contents");
+    }
 }

--- a/src/main/java/com/senither/hypixel/rank/checkers/TalismansChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/TalismansChecker.java
@@ -40,6 +40,16 @@ import java.util.UUID;
 public class TalismansChecker extends RankRequirementChecker {
 
     @Override
+    public String getRankRequirementNote(GuildController.GuildEntry.RankRequirement requirement) {
+        if (requirement.getTalismansLegendary() == Integer.MAX_VALUE || requirement.getTalismansEpic() == Integer.MAX_VALUE) {
+            return "No Talisman requirement";
+        }
+        return String.format("Must have %s Legendaries, and %s Epic Talismans",
+            requirement.getTalismansLegendary(), requirement.getTalismansEpic()
+        );
+    }
+
+    @Override
     public RankCheckResponse getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
         JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
 

--- a/src/main/java/com/senither/hypixel/rank/checkers/TalismansChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/TalismansChecker.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank.checkers;
+
+import com.senither.hypixel.contracts.rank.RankRequirementChecker;
+
+public class TalismansChecker extends RankRequirementChecker {
+
+}

--- a/src/main/java/com/senither/hypixel/rank/checkers/TalismansChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/TalismansChecker.java
@@ -25,7 +25,6 @@ import com.google.gson.JsonObject;
 import com.senither.hypixel.contracts.rank.RankRequirementChecker;
 import com.senither.hypixel.database.controller.GuildController;
 import com.senither.hypixel.exceptions.FriendlyException;
-import com.senither.hypixel.inventory.Inventory;
 import com.senither.hypixel.inventory.Item;
 import com.senither.hypixel.inventory.ItemType;
 import net.hypixel.api.reply.GuildReply;
@@ -48,9 +47,9 @@ public class TalismansChecker extends RankRequirementChecker {
 
         try {
             List<Item> talismans = new ArrayList<>();
-            talismans.addAll(getTalismansFromInventory(member, "ender_chest_contents"));
-            talismans.addAll(getTalismansFromInventory(member, "talisman_bag"));
-            talismans.addAll(getTalismansFromInventory(member, "inv_contents"));
+            talismans.addAll(buildInventoryForPlayer(member, "ender_chest_contents").getItemsWithType(ItemType.ACCESSORY));
+            talismans.addAll(buildInventoryForPlayer(member, "talisman_bag").getItemsWithType(ItemType.ACCESSORY));
+            talismans.addAll(buildInventoryForPlayer(member, "inv_contents").getItemsWithType(ItemType.ACCESSORY));
 
             int epics = 0;
             int legendaries = 0;
@@ -79,12 +78,6 @@ public class TalismansChecker extends RankRequirementChecker {
         } catch (IOException ignored) {
         }
         return null;
-    }
-
-    private List<Item> getTalismansFromInventory(JsonObject member, String inventoryName) throws IOException {
-        Inventory inventory = new Inventory(member.get(inventoryName).getAsJsonObject().get("data").getAsString());
-
-        return inventory.getItemsWithType(ItemType.ACCESSORY);
     }
 
     private boolean isInventoryApiEnabled(JsonObject json) {

--- a/src/main/java/com/senither/hypixel/rank/checkers/WeaponsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/WeaponsChecker.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank.checkers;
+
+import com.senither.hypixel.contracts.rank.RankRequirementChecker;
+
+public class WeaponsChecker extends RankRequirementChecker {
+}

--- a/src/main/java/com/senither/hypixel/rank/checkers/WeaponsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/WeaponsChecker.java
@@ -38,6 +38,22 @@ import java.util.*;
 public class WeaponsChecker extends RankRequirementChecker {
 
     @Override
+    public String getRankRequirementNote(GuildController.GuildEntry.RankRequirement requirement) {
+        if (requirement.getWeaponPoints() == Integer.MAX_VALUE || requirement.getWeaponItems().isEmpty()) {
+            return "No Weapon requirement";
+        }
+
+        List<String> items = new ArrayList<>();
+        for (Map.Entry<String, Integer> entry : requirement.getWeaponItems().entrySet()) {
+            items.add(String.format("%s = %s", entry.getKey(), entry.getValue()));
+        }
+
+        return String.format("Must have %s Weapon Points, Items:\n\n%s",
+            requirement.getWeaponPoints(), String.join("\n", items)
+        );
+    }
+
+    @Override
     public RankCheckResponse getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
         JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
 

--- a/src/main/java/com/senither/hypixel/rank/checkers/WeaponsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/WeaponsChecker.java
@@ -27,6 +27,7 @@ import com.senither.hypixel.database.controller.GuildController;
 import com.senither.hypixel.exceptions.FriendlyException;
 import com.senither.hypixel.inventory.Item;
 import com.senither.hypixel.inventory.ItemType;
+import com.senither.hypixel.rank.RankCheckResponse;
 import com.senither.hypixel.rank.items.Weapon;
 import net.hypixel.api.reply.GuildReply;
 import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
@@ -37,7 +38,7 @@ import java.util.*;
 public class WeaponsChecker extends RankRequirementChecker {
 
     @Override
-    public GuildReply.Guild.Rank getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
+    public RankCheckResponse getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
         JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
 
         if (!isInventoryApiEnabled(member)) {
@@ -77,12 +78,18 @@ public class WeaponsChecker extends RankRequirementChecker {
                 }
 
                 if (points >= requirement.getWeaponPoints()) {
-                    return rank;
+                    return createResponse(rank, points);
                 }
             }
         } catch (IOException ignored) {
         }
-        return null;
+        return createResponse(null, 0);
+    }
+
+    private RankCheckResponse createResponse(GuildReply.Guild.Rank rank, int points) {
+        return new RankCheckResponse(rank, new HashMap<String, Object>() {{
+            put("points", points);
+        }});
     }
 
     private boolean isInventoryApiEnabled(JsonObject json) {

--- a/src/main/java/com/senither/hypixel/rank/checkers/WeaponsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/WeaponsChecker.java
@@ -21,7 +21,69 @@
 
 package com.senither.hypixel.rank.checkers;
 
+import com.google.gson.JsonObject;
 import com.senither.hypixel.contracts.rank.RankRequirementChecker;
+import com.senither.hypixel.database.controller.GuildController;
+import com.senither.hypixel.exceptions.FriendlyException;
+import com.senither.hypixel.inventory.Item;
+import com.senither.hypixel.inventory.ItemType;
+import com.senither.hypixel.rank.items.Weapon;
+import net.hypixel.api.reply.GuildReply;
+import net.hypixel.api.reply.skyblock.SkyBlockProfileReply;
+
+import java.io.IOException;
+import java.util.*;
 
 public class WeaponsChecker extends RankRequirementChecker {
+
+    @Override
+    public GuildReply.Guild.Rank getRankForUser(GuildController.GuildEntry guildEntry, GuildReply guildReply, SkyBlockProfileReply profileReply, UUID playerUUID) {
+        JsonObject member = profileReply.getProfile().getAsJsonObject("members").getAsJsonObject(playerUUID.toString().replace("-", ""));
+
+        if (!isInventoryApiEnabled(member)) {
+            throw new FriendlyException("Inventory API is disabled, unable to look for weapons");
+        }
+
+        try {
+            List<Item> items = new ArrayList<>();
+            items.addAll(buildInventoryForPlayer(member, "ender_chest_contents").getItemsWithType(ItemType.WEAPON));
+            items.addAll(buildInventoryForPlayer(member, "inv_contents").getItemsWithType(ItemType.WEAPON));
+
+            for (GuildReply.Guild.Rank rank : getSortedRanksFromGuild(guildReply)) {
+                if (!guildEntry.getRankRequirements().containsKey(rank.getName())) {
+                    continue;
+                }
+
+                EnumMap<Weapon, Integer> weapons = new EnumMap<>(Weapon.class);
+                GuildController.GuildEntry.RankRequirement requirement = guildEntry.getRankRequirements().get(rank.getName());
+
+                for (Map.Entry<String, Integer> weaponEntry : requirement.getWeaponItems().entrySet()) {
+                    Weapon weapon = Weapon.getFromName(weaponEntry.getKey());
+                    if (weapon != null) {
+                        weapons.put(weapon, weaponEntry.getValue());
+                    }
+                }
+
+                int points = 0;
+                for (Map.Entry<Weapon, Integer> weaponIntegerEntry : weapons.entrySet()) {
+                    for (Item item : items) {
+                        if (item.getName().endsWith(weaponIntegerEntry.getKey().getName())) {
+                            points += weaponIntegerEntry.getValue();
+                        }
+                    }
+                }
+
+                if (points >= requirement.getWeaponPoints()) {
+                    return rank;
+                }
+            }
+        } catch (IOException ignored) {
+        }
+        return null;
+    }
+
+    private boolean isInventoryApiEnabled(JsonObject json) {
+        return json.has("ender_chest_contents")
+            && json.has("inv_contents");
+    }
 }

--- a/src/main/java/com/senither/hypixel/rank/checkers/WeaponsChecker.java
+++ b/src/main/java/com/senither/hypixel/rank/checkers/WeaponsChecker.java
@@ -54,9 +54,12 @@ public class WeaponsChecker extends RankRequirementChecker {
                     continue;
                 }
 
-                EnumMap<Weapon, Integer> weapons = new EnumMap<>(Weapon.class);
                 GuildController.GuildEntry.RankRequirement requirement = guildEntry.getRankRequirements().get(rank.getName());
+                if (requirement.getWeaponItems().isEmpty() || requirement.getWeaponPoints() == Integer.MAX_VALUE) {
+                    continue;
+                }
 
+                EnumMap<Weapon, Integer> weapons = new EnumMap<>(Weapon.class);
                 for (Map.Entry<String, Integer> weaponEntry : requirement.getWeaponItems().entrySet()) {
                     Weapon weapon = Weapon.getFromName(weaponEntry.getKey());
                     if (weapon != null) {

--- a/src/main/java/com/senither/hypixel/rank/handler/CustomObjectValueHandler.java
+++ b/src/main/java/com/senither/hypixel/rank/handler/CustomObjectValueHandler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank.handler;
+
+import com.senither.hypixel.SkyblockAssistant;
+import com.senither.hypixel.chat.MessageFactory;
+import com.senither.hypixel.contracts.rank.ObjectClosure;
+import com.senither.hypixel.contracts.rank.RankCommandHandler;
+import com.senither.hypixel.database.controller.GuildController;
+import com.senither.hypixel.exceptions.FriendlyException;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.hypixel.api.reply.GuildReply;
+
+import java.util.function.Function;
+
+public class CustomObjectValueHandler<T> extends RankCommandHandler {
+
+    private final Function<Object, T> getter;
+    private final ObjectClosure<T> closure;
+
+    public CustomObjectValueHandler(Function<Object, T> getter, ObjectClosure<T> closure) {
+        this.getter = getter;
+        this.closure = closure;
+    }
+
+    @Override
+    public void handle(SkyblockAssistant app, MessageReceivedEvent event, GuildController.GuildEntry guildEntry, GuildReply.Guild.Rank rank, String[] args) {
+        if (args.length == 0) {
+            throw new FriendlyException(String.format(
+                "Missing argument for %s requirement",
+                rankType.getName()
+            ));
+        }
+
+        T response = getter.apply(args[0]);
+        closure.run(getRequirementsForRank(guildEntry, rank), response);
+
+        updateGuildEntry(app, event, guildEntry);
+
+        MessageFactory.makeSuccess(event.getMessage(),
+            "The new :type requirement for **:rank** have successfully been set to **:value**."
+        )
+            .set("type", rankType.getName())
+            .set("rank", rank.getName())
+            .set("value", response == null ? "nothing" : response)
+            .queue();
+    }
+}

--- a/src/main/java/com/senither/hypixel/rank/handler/DoubleObjectValueHandler.java
+++ b/src/main/java/com/senither/hypixel/rank/handler/DoubleObjectValueHandler.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank.handler;
+
+import com.senither.hypixel.SkyblockAssistant;
+import com.senither.hypixel.chat.MessageFactory;
+import com.senither.hypixel.contracts.rank.ObjectClosure;
+import com.senither.hypixel.contracts.rank.RankCommandHandler;
+import com.senither.hypixel.database.controller.GuildController;
+import com.senither.hypixel.exceptions.FriendlyException;
+import com.senither.hypixel.utils.NumberUtil;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.hypixel.api.reply.GuildReply;
+
+public class DoubleObjectValueHandler extends RankCommandHandler {
+
+    private final ObjectClosure<Integer> closureFirst;
+    private final ObjectClosure<Integer> closureSecond;
+    private final String message;
+
+    public DoubleObjectValueHandler(ObjectClosure<Integer> closureFirst, ObjectClosure<Integer> closureSecond, String message) {
+        this.closureFirst = closureFirst;
+        this.closureSecond = closureSecond;
+        this.message = message;
+    }
+
+    @Override
+    public void handle(SkyblockAssistant app, MessageReceivedEvent event, GuildController.GuildEntry guildEntry, GuildReply.Guild.Rank rank, String[] args) {
+        if (args.length == 0 || !NumberUtil.isNumeric(args[0])) {
+            throw new FriendlyException(String.format(
+                "The first %s value must be a number!",
+                rankType.getName()
+            ));
+        }
+
+        if (args.length == 1 || !NumberUtil.isNumeric(args[1])) {
+            throw new FriendlyException(String.format(
+                "The second %s value must be a number!",
+                rankType.getName()
+            ));
+        }
+
+        int first = NumberUtil.parseInt(args[0], Integer.MAX_VALUE);
+        int second = NumberUtil.parseInt(args[1], Integer.MAX_VALUE);
+
+        closureFirst.run(getRequirementsForRank(guildEntry, rank), first);
+        closureSecond.run(getRequirementsForRank(guildEntry, rank), second);
+
+        updateGuildEntry(app, event, guildEntry);
+
+        MessageFactory.makeSuccess(event.getMessage(), message == null
+            ? "The new :type requirement for **:rank** have successfully been set to **:first** and **:second**."
+            : message
+        )
+            .set("type", rankType.getName())
+            .set("rank", rank.getName())
+            .set("first", first)
+            .set("second", second)
+            .queue();
+    }
+}

--- a/src/main/java/com/senither/hypixel/rank/handler/IntegerValueHandler.java
+++ b/src/main/java/com/senither/hypixel/rank/handler/IntegerValueHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank.handler;
+
+import com.senither.hypixel.SkyblockAssistant;
+import com.senither.hypixel.chat.MessageFactory;
+import com.senither.hypixel.contracts.rank.ObjectClosure;
+import com.senither.hypixel.contracts.rank.RankCommandHandler;
+import com.senither.hypixel.database.controller.GuildController;
+import com.senither.hypixel.exceptions.FriendlyException;
+import com.senither.hypixel.utils.NumberUtil;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.hypixel.api.reply.GuildReply;
+
+public class IntegerValueHandler extends RankCommandHandler {
+
+    private final ObjectClosure<Integer> closure;
+
+    public IntegerValueHandler(ObjectClosure<Integer> closure) {
+        this.closure = closure;
+    }
+
+    @Override
+    public void handle(SkyblockAssistant app, MessageReceivedEvent event, GuildController.GuildEntry guildEntry, GuildReply.Guild.Rank rank, String[] args) {
+        if (args.length == 0 || !NumberUtil.isNumeric(args[0])) {
+            throw new FriendlyException(String.format(
+                "The %s value must be a number!",
+                rankType.getName()
+            ));
+        }
+
+        int value = NumberUtil.parseInt(args[0], Integer.MAX_VALUE);
+
+        closure.run(getRequirementsForRank(guildEntry, rank), value);
+        updateGuildEntry(app, event, guildEntry);
+
+        MessageFactory.makeSuccess(event.getMessage(), "The new :type requirement for **:rank** have successfully been set to **:value**")
+            .set("type", rankType.getName())
+            .set("rank", rank.getName())
+            .set("value", value)
+            .queue();
+    }
+}

--- a/src/main/java/com/senither/hypixel/rank/handler/ItemValueHandler.java
+++ b/src/main/java/com/senither/hypixel/rank/handler/ItemValueHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank.handler;
+
+import com.senither.hypixel.SkyblockAssistant;
+import com.senither.hypixel.contracts.rank.ObjectClosure;
+import com.senither.hypixel.contracts.rank.RankCommandHandler;
+import com.senither.hypixel.database.controller.GuildController;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.hypixel.api.reply.GuildReply;
+
+import java.util.HashMap;
+import java.util.function.Function;
+
+public class ItemValueHandler extends RankCommandHandler {
+
+    private final ObjectClosure<Integer> closure;
+    private final Function<GuildController.GuildEntry.RankRequirement, HashMap<String, Integer>> getter;
+
+    public ItemValueHandler(ObjectClosure<Integer> closure, Function<GuildController.GuildEntry.RankRequirement, HashMap<String, Integer>> getter) {
+        this.closure = closure;
+        this.getter = getter;
+    }
+
+    @Override
+    public void handle(SkyblockAssistant app, MessageReceivedEvent event, GuildController.GuildEntry guildEntry, GuildReply.Guild.Rank rank, String[] args) {
+
+    }
+}

--- a/src/main/java/com/senither/hypixel/rank/handler/ItemValueHandler.java
+++ b/src/main/java/com/senither/hypixel/rank/handler/ItemValueHandler.java
@@ -22,27 +22,113 @@
 package com.senither.hypixel.rank.handler;
 
 import com.senither.hypixel.SkyblockAssistant;
+import com.senither.hypixel.chat.MessageFactory;
+import com.senither.hypixel.contracts.rank.ItemRequirement;
 import com.senither.hypixel.contracts.rank.ObjectClosure;
 import com.senither.hypixel.contracts.rank.RankCommandHandler;
 import com.senither.hypixel.database.controller.GuildController;
+import com.senither.hypixel.exceptions.FriendlyException;
+import com.senither.hypixel.utils.NumberUtil;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.hypixel.api.reply.GuildReply;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.function.Function;
 
 public class ItemValueHandler extends RankCommandHandler {
 
-    private final ObjectClosure<Integer> closure;
+    private final IntegerValueHandler pointHandler;
     private final Function<GuildController.GuildEntry.RankRequirement, HashMap<String, Integer>> getter;
+    private final ItemRequirement[] items;
 
-    public ItemValueHandler(ObjectClosure<Integer> closure, Function<GuildController.GuildEntry.RankRequirement, HashMap<String, Integer>> getter) {
-        this.closure = closure;
+    public ItemValueHandler(ObjectClosure<Integer> closure, Function<GuildController.GuildEntry.RankRequirement, HashMap<String, Integer>> getter, ItemRequirement[] items) {
+        this.pointHandler = new IntegerValueHandler(closure);
         this.getter = getter;
+        this.items = items;
     }
 
     @Override
     public void handle(SkyblockAssistant app, MessageReceivedEvent event, GuildController.GuildEntry guildEntry, GuildReply.Guild.Rank rank, String[] args) {
+        if (args.length == 0) {
+            throw new FriendlyException(
+                "Missing option given for setting %s, you must either use `points` or `item`",
+                rankType.getName()
+            );
+        }
 
+        switch (args[0].toLowerCase()) {
+            case "point":
+            case "points":
+                pointHandler.setRankType(rankType);
+                pointHandler.handle(app, event, guildEntry, rank, Arrays.copyOfRange(args, 1, args.length));
+                break;
+
+            case "gear":
+            case "item":
+            case "items":
+                handleItem(app, event, guildEntry, rank, Arrays.copyOfRange(args, 1, args.length));
+                break;
+
+            default:
+                throw new FriendlyException(String.format(
+                    "Invalid option given for setting %s, you must either use `points` or `item`",
+                    rankType.getName()
+                ));
+        }
+    }
+
+    private void handleItem(SkyblockAssistant app, MessageReceivedEvent event, GuildController.GuildEntry guildEntry, GuildReply.Guild.Rank rank, String[] args) {
+        if (args.length == 0) {
+            throw new FriendlyException(
+                "You must provide the name of the %s you want to use.",
+                rankType.getName()
+            );
+        }
+
+        int points = -1;
+        String itemName = String.join(" ", args).toLowerCase();
+
+        if (args.length > 1 && NumberUtil.isNumeric(args[args.length - 1])) {
+            itemName = String.join(" ", Arrays.copyOfRange(
+                args, 0, args.length - 1
+            )).toLowerCase();
+            points = NumberUtil.parseInt(args[args.length - 1], 1);
+        }
+
+        ItemRequirement selectedItem = null;
+        for (ItemRequirement item : items) {
+            if (item.getAliases().contains(itemName) || item.getName().equalsIgnoreCase(itemName)) {
+                selectedItem = item;
+                break;
+            }
+        }
+
+        if (selectedItem == null) {
+            throw new FriendlyException(
+                "Unrecognized %s, `%s` is not a valid %s!",
+                rankType.getName(), itemName, rankType.getName()
+            );
+        }
+
+        HashMap<String, Integer> storedItems = getter.apply(getRequirementsForRank(guildEntry, rank));
+
+        if (points < 0) {
+            storedItems.remove(selectedItem.getName());
+        } else {
+            storedItems.put(selectedItem.getName(), points);
+        }
+
+        updateGuildEntry(app, event, guildEntry);
+
+        MessageFactory.makeSuccess(event.getMessage(), points < 0
+            ? "The **:name** :type was removed from the :type requirement for **:rank**!"
+            : "The **:name** :type has been added for the **:rank** rank, It's worth **:points**"
+        )
+            .set("type", rankType.getName())
+            .set("rank", rank.getName())
+            .set("name", selectedItem.getName())
+            .set("points", points)
+            .queue();
     }
 }

--- a/src/main/java/com/senither/hypixel/rank/items/Armor.java
+++ b/src/main/java/com/senither/hypixel/rank/items/Armor.java
@@ -21,74 +21,87 @@
 
 package com.senither.hypixel.rank.items;
 
+import com.senither.hypixel.contracts.rank.ItemRequirement;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 @SuppressWarnings("SpellCheckingInspection")
-public enum Armor {
+public enum Armor implements ItemRequirement {
 
     ELEGANT_TUXEDO(new ArmorSet(
+        "Elegant Tuxedo",
         null,
         "Elegant Tuxedo Jacket",
         "Elegant Tuxedo Pants",
         "Elegant Tuxedo Oxfords"
     ), "elegant tuxedo", "etux"),
     SUPERIOR_DRAGON_ARMOR(new ArmorSet(
+        "Superior Dragon Armor",
         "Superior Dragon Helmet",
         "Superior Dragon Chestplate",
         "Superior Dragon Leggings",
         "Superior Dragon Boots"
     ), "superior dragon", "superior"),
     STRONG_DRAGON_ARMOR(new ArmorSet(
+        "Strong Dragon Armor",
         "Strong Dragon Helmet",
         "Strong Dragon Chestplate",
         "Strong Dragon Leggings",
         "Strong Dragon Boots"
     ), "strong dragon", "strong"),
     UNSTABLE_DRAGON_ARMOR(new ArmorSet(
+        "Unstable Dragon Armor",
         "Unstable Dragon Helmet",
         "Unstable Dragon Chestplate",
         "Unstable Dragon Leggings",
         "Unstable Dragon Boots"
     ), "unstable dragon", "unstable"),
     WISE_DRAGON_ARMOR(new ArmorSet(
+        "Wise Dragon Armor",
         "Wise Dragon Helmet",
         "Wise Dragon Chestplate",
         "Wise Dragon Leggings",
         "Wise Dragon Boots"
     ), "wise dragon", "wise"),
     YOUNG_DRAGON_ARMOR(new ArmorSet(
+        "Young Dragon Armor",
         "Young Dragon Helmet",
         "Young Dragon Chestplate",
         "Young Dragon Leggings",
         "Young Dragon Boots"
     ), "young dragon", "young"),
     PROTECTOR_DRAGON_ARMOR(new ArmorSet(
+        "Protector Dragon Armor",
         "Protector Dragon Helmet",
         "Protector Dragon Chestplate",
         "Protector Dragon Leggings",
         "Protector Dragon Boots"
     ), "protector dragon", "protector"),
     OLD_DRAGON_ARMOR(new ArmorSet(
+        "Old Dragon Armor",
         "Old Dragon Helmet",
         "Old Dragon Chestplate",
         "Old Dragon Leggings",
         "Old Dragon Boots"
     ), "old dragon", "old", "boomer"),
     REVENANT_ARMOR(new ArmorSet(
+        "Revenant Horror Armor",
         null,
         "Revenant Chestplate",
         "Revenant Leggings",
         "Revenant Boots"
     ), "revenant", "rev"),
     TARANTULA_ARMOR(new ArmorSet(
+        "Tarantula Armor",
         "Tarantula Helmet",
         "Tarantula Chestplate",
         "Tarantula Leggings",
         "Tarantula Boots"
     ), "tarantula", "tara"),
     MASTIFF_ARMOR(new ArmorSet(
+        "Mastiff Armor",
         "Mastiff Helmet",
         "Mastiff Chestplate",
         "Mastiff Leggings",
@@ -107,17 +120,23 @@ public enum Armor {
 
     public static Armor getFromName(String name) {
         for (Armor armor : values()) {
-            if (armor.getAliases().contains(name.toLowerCase())) {
+            if (armor.getName().equalsIgnoreCase(name) || armor.getAliases().contains(name.toLowerCase())) {
                 return armor;
             }
         }
         return null;
     }
 
+    @Override
+    public String getName() {
+        return getArmorSet().getName();
+    }
+
     public ArmorSet getArmorSet() {
         return armorSet;
     }
 
+    @Override
     public List<String> getAliases() {
         return aliases;
     }

--- a/src/main/java/com/senither/hypixel/rank/items/Armor.java
+++ b/src/main/java/com/senither/hypixel/rank/items/Armor.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank.items;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@SuppressWarnings("SpellCheckingInspection")
+public enum Armor {
+
+    ELEGANT_TUXEDO(new ArmorSet(
+        null,
+        "Elegant Tuxedo Jacket",
+        "Elegant Tuxedo Pants",
+        "Elegant Tuxedo Oxfords"
+    ), "elegant tuxedo", "etux"),
+    SUPERIOR_DRAGON_ARMOR(new ArmorSet(
+        "Superior Dragon Helmet",
+        "Superior Dragon Chestplate",
+        "Superior Dragon Leggings",
+        "Superior Dragon Boots"
+    ), "superior dragon", "superior"),
+    STRONG_DRAGON_ARMOR(new ArmorSet(
+        "Strong Dragon Helmet",
+        "Strong Dragon Chestplate",
+        "Strong Dragon Leggings",
+        "Strong Dragon Boots"
+    ), "strong dragon", "strong"),
+    UNSTABLE_DRAGON_ARMOR(new ArmorSet(
+        "Unstable Dragon Helmet",
+        "Unstable Dragon Chestplate",
+        "Unstable Dragon Leggings",
+        "Unstable Dragon Boots"
+    ), "unstable dragon", "unstable"),
+    WISE_DRAGON_ARMOR(new ArmorSet(
+        "Wise Dragon Helmet",
+        "Wise Dragon Chestplate",
+        "Wise Dragon Leggings",
+        "Wise Dragon Boots"
+    ), "wise dragon", "wise"),
+    YOUNG_DRAGON_ARMOR(new ArmorSet(
+        "Young Dragon Helmet",
+        "Young Dragon Chestplate",
+        "Young Dragon Leggings",
+        "Young Dragon Boots"
+    ), "young dragon", "young"),
+    PROTECTOR_DRAGON_ARMOR(new ArmorSet(
+        "Protector Dragon Helmet",
+        "Protector Dragon Chestplate",
+        "Protector Dragon Leggings",
+        "Protector Dragon Boots"
+    ), "protector dragon", "protector"),
+    OLD_DRAGON_ARMOR(new ArmorSet(
+        "Old Dragon Helmet",
+        "Old Dragon Chestplate",
+        "Old Dragon Leggings",
+        "Old Dragon Boots"
+    ), "old dragon", "old", "boomer"),
+    REVENANT_ARMOR(new ArmorSet(
+        null,
+        "Revenant Chestplate",
+        "Revenant Leggings",
+        "Revenant Boots"
+    ), "revenant", "rev"),
+    TARANTULA_ARMOR(new ArmorSet(
+        "Tarantula Helmet",
+        "Tarantula Chestplate",
+        "Tarantula Leggings",
+        "Tarantula Boots"
+    ), "tarantula", "tara"),
+    MASTIFF_ARMOR(new ArmorSet(
+        "Mastiff Helmet",
+        "Mastiff Chestplate",
+        "Mastiff Leggings",
+        "Mastiff Boots"
+    ), "mastiff");
+
+    private final ArmorSet armorSet;
+    private final List<String> aliases;
+
+    Armor(ArmorSet armorSet, String... keywords) {
+        this.armorSet = armorSet;
+        this.aliases = new ArrayList<>();
+        this.aliases.add(name().replaceAll("_", " ").toLowerCase());
+        this.aliases.addAll(Arrays.asList(keywords));
+    }
+
+    public static Armor getFromName(String name) {
+        for (Armor armor : values()) {
+            if (armor.getAliases().contains(name.toLowerCase())) {
+                return armor;
+            }
+        }
+        return null;
+    }
+
+    public ArmorSet getArmorSet() {
+        return armorSet;
+    }
+
+    public List<String> getAliases() {
+        return aliases;
+    }
+}

--- a/src/main/java/com/senither/hypixel/rank/items/ArmorSet.java
+++ b/src/main/java/com/senither/hypixel/rank/items/ArmorSet.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank.items;
+
+public class ArmorSet {
+
+    private final String helmet;
+    private final String chestplate;
+    private final String leggings;
+    private final String boots;
+
+    private final int setPieces;
+
+    ArmorSet(String helmet, String chestplate, String leggings, String boots) {
+        this.helmet = helmet;
+        this.chestplate = chestplate;
+        this.leggings = leggings;
+        this.boots = boots;
+
+        int pieces = helmet == null ? 0 : 1;
+        pieces += chestplate == null ? 0 : 1;
+        pieces += leggings == null ? 0 : 1;
+        pieces += boots == null ? 0 : 1;
+
+        this.setPieces = pieces;
+    }
+
+    public String getHelmet() {
+        return helmet;
+    }
+
+    public String getChestplate() {
+        return chestplate;
+    }
+
+    public String getLeggings() {
+        return leggings;
+    }
+
+    public String getBoots() {
+        return boots;
+    }
+
+    public int getSetPieces() {
+        return setPieces;
+    }
+
+    public boolean isPartOfSet(String itemName) {
+        return (helmet != null && itemName.endsWith(helmet))
+            || (chestplate != null && itemName.endsWith(chestplate))
+            || (leggings != null && itemName.endsWith(leggings))
+            || (boots != null && itemName.endsWith(boots));
+    }
+}

--- a/src/main/java/com/senither/hypixel/rank/items/ArmorSet.java
+++ b/src/main/java/com/senither/hypixel/rank/items/ArmorSet.java
@@ -23,6 +23,8 @@ package com.senither.hypixel.rank.items;
 
 public class ArmorSet {
 
+    private final String name;
+
     private final String helmet;
     private final String chestplate;
     private final String leggings;
@@ -30,7 +32,9 @@ public class ArmorSet {
 
     private final int setPieces;
 
-    ArmorSet(String helmet, String chestplate, String leggings, String boots) {
+    ArmorSet(String name, String helmet, String chestplate, String leggings, String boots) {
+        this.name = name;
+
         this.helmet = helmet;
         this.chestplate = chestplate;
         this.leggings = leggings;
@@ -42,6 +46,10 @@ public class ArmorSet {
         pieces += boots == null ? 0 : 1;
 
         this.setPieces = pieces;
+    }
+
+    public String getName() {
+        return name;
     }
 
     public String getHelmet() {

--- a/src/main/java/com/senither/hypixel/rank/items/PowerOrb.java
+++ b/src/main/java/com/senither/hypixel/rank/items/PowerOrb.java
@@ -23,9 +23,9 @@ package com.senither.hypixel.rank.items;
 
 public enum PowerOrb {
 
-    RADIANT_ORB(1, "Radiant Orb"),
-    MANA_FLUX(2, "Mana Flux"),
-    OVERFLUX(3, "Overflux");
+    RADIANT_ORB(1, "Radiant Power Orb"),
+    MANA_FLUX(2, "Mana Flux Power Orb"),
+    OVERFLUX(3, "Overflux Power Orb");
 
     private final int id;
     private final String name;

--- a/src/main/java/com/senither/hypixel/rank/items/PowerOrb.java
+++ b/src/main/java/com/senither/hypixel/rank/items/PowerOrb.java
@@ -44,11 +44,25 @@ public enum PowerOrb {
         return null;
     }
 
+    public static PowerOrb fromName(String name) {
+        for (PowerOrb orb : values()) {
+            if (orb.getName().equalsIgnoreCase(name) || orb.name().equalsIgnoreCase(name)) {
+                return orb;
+            }
+        }
+        return null;
+    }
+
     public int getId() {
         return id;
     }
 
     public String getName() {
         return name;
+    }
+
+    @Override
+    public String toString() {
+        return getName();
     }
 }

--- a/src/main/java/com/senither/hypixel/rank/items/PowerOrb.java
+++ b/src/main/java/com/senither/hypixel/rank/items/PowerOrb.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank.items;
+
+public enum PowerOrb {
+
+    RADIANT_ORB(1, "Radiant Orb"),
+    MANA_FLUX(2, "Mana Flux"),
+    OVERFLUX(3, "Overflux");
+
+    private final int id;
+    private final String name;
+
+    PowerOrb(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public static PowerOrb fromId(int id) {
+        for (PowerOrb orb : values()) {
+            if (orb.getId() == id) {
+                return orb;
+            }
+        }
+        return null;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/senither/hypixel/rank/items/Weapon.java
+++ b/src/main/java/com/senither/hypixel/rank/items/Weapon.java
@@ -21,12 +21,14 @@
 
 package com.senither.hypixel.rank.items;
 
+import com.senither.hypixel.contracts.rank.ItemRequirement;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 @SuppressWarnings("SpellCheckingInspection")
-public enum Weapon {
+public enum Weapon implements ItemRequirement {
 
     REAPER_SCYTHE("Reaper Scythe", "scythe"),
     ASPECT_OF_THE_DRAGONS("Aspect of the Dragons", "aotd"),
@@ -60,10 +62,12 @@ public enum Weapon {
         return null;
     }
 
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public List<String> getAliases() {
         return aliases;
     }

--- a/src/main/java/com/senither/hypixel/rank/items/Weapon.java
+++ b/src/main/java/com/senither/hypixel/rank/items/Weapon.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020.
+ *
+ * This file is part of Hypixel Skyblock Assistant.
+ *
+ * Hypixel Guild Synchronizer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Hypixel Guild Synchronizer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hypixel Guild Synchronizer.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.senither.hypixel.rank.items;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@SuppressWarnings("SpellCheckingInspection")
+public enum Weapon {
+
+    REAPER_SCYTHE("Reaper Scythe", "scythe"),
+    ASPECT_OF_THE_DRAGONS("Aspect of the Dragons", "aotd"),
+    PIGMAN_SWORD("Pigman Sword", "pig sword", "pigman"),
+    THICK_SCORPION_FOIL("Thick Scorpion Foil", "foil"),
+    POOCH_SWORD("Pooch Sword", "pooch"),
+    REAPER_FALCHION("Reaper Falchion", "falchion"),
+    LEAPING_SWORD("Leaping Sword", "leaping"),
+    ASPECT_OF_THE_END("Aspect of the End", "aote"),
+    RAIDER_AXE("Raider Axe", "raider"),
+    RUNAANS_BOW("Runnan's Bow", "runnan's", "runnans"),
+    HURRICANE_BOW("Hurricane Bow", "hurricane"),
+    SCORPION_BOW("Scorpion Bow", "scorpion");
+
+    private final String name;
+    private final List<String> aliases;
+
+    Weapon(String name, String... keywords) {
+        this.name = name;
+        this.aliases = new ArrayList<>();
+        this.aliases.add(name().replaceAll("_", " ").toLowerCase());
+        this.aliases.addAll(Arrays.asList(keywords));
+    }
+
+    public static Weapon getFromName(String name) {
+        for (Weapon weapon : values()) {
+            if (weapon.getAliases().contains(name.toLowerCase())) {
+                return weapon;
+            }
+        }
+        return null;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<String> getAliases() {
+        return aliases;
+    }
+}

--- a/src/main/java/com/senither/hypixel/utils/NumberUtil.java
+++ b/src/main/java/com/senither/hypixel/utils/NumberUtil.java
@@ -21,10 +21,13 @@
 
 package com.senither.hypixel.utils;
 
+import javax.annotation.Nonnull;
 import java.text.DecimalFormat;
+import java.util.regex.Pattern;
 
 public class NumberUtil {
 
+    private static final Pattern numberPattern = Pattern.compile("[-+]?\\d*\\.?\\d+");
     private static final DecimalFormat niceFormat = new DecimalFormat("#,##0");
     private static final DecimalFormat niceFormatWithDecimal = new DecimalFormat("#,###.##");
 
@@ -50,5 +53,9 @@ public class NumberUtil {
 
     public static String formatNicelyWithDecimals(double value) {
         return niceFormatWithDecimal.format(value);
+    }
+
+    public static boolean isNumeric(@Nonnull String string) {
+        return numberPattern.matcher(string).matches();
     }
 }


### PR DESCRIPTION
This PR adds support for setting up the required average skill level, fairy soul, talismans, slayer, talismans, weapon, and armor requirements for each rank, and then using that information to let the bot check what rank a user should belong to.